### PR TITLE
fix: skip empty updates in linkUsers

### DIFF
--- a/functions/levante-admin/src/user-linking.ts
+++ b/functions/levante-admin/src/user-linking.ts
@@ -116,6 +116,9 @@ async function updateUserDoc(
         updates[key] = FieldValue.arrayUnion(...values);
       }
     }
+    if (Object.keys(updates).length === 0) {
+      return;
+    }
     await userRef.update(updates);
   }
 }


### PR DESCRIPTION
## Summary
- skip user doc updates when no link targets are present
- prevent Firestore update({}) errors for orphan child rows
- closes #39

## Test plan
- [ ] Not run (logic-only change)