### PR TITLE
POC: Prevent null org targeting on administration updates

### DIFF
--- a/.github/workflows/pipeline-contract-compat.yml
+++ b/.github/workflows/pipeline-contract-compat.yml
@@ -1,0 +1,71 @@
+name: Pipeline Contract Compatibility
+
+on:
+  schedule:
+    - cron: '30 5 * * *'
+  pull_request:
+    paths:
+      - 'functions/levante-admin/src/**'
+      - 'functions/levante-admin/firestore.rules'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  contract-compatibility:
+    if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'pipeline-contract-check') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout firebase functions
+        uses: actions/checkout@v4
+        with:
+          path: levante-firebase-functions
+
+      - name: Checkout support contracts
+        uses: actions/checkout@v4
+        with:
+          repository: levante-framework/levante-support
+          path: levante-support
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: levante-firebase-functions/package-lock.json
+
+      - name: Install firebase-functions dependencies
+        working-directory: levante-firebase-functions
+        run: npm ci
+
+      - name: Validate upstream contract invariants
+        working-directory: levante-firebase-functions
+        env:
+          PIPELINE_CONTRACT_PATH: ${{ github.workspace }}/levante-support/schema_tools/PIPELINE_DATA_CONTRACT.json
+        run: |
+          npm run contract:check
+          npx vitest run "__tests__/save-survey-results.contract.test.ts"
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Install R dependencies for fixture checks
+        run: |
+          Rscript -e "install.packages(c('dplyr','here','jsonlite','readr','tibble'), repos='https://cloud.r-project.org')"
+
+      - name: Validate pilots fixture compatibility (stages 01-04)
+        working-directory: levante-support
+        env:
+          PIPELINE_CONTRACT_PATH: ${{ github.workspace }}/levante-support/schema_tools/PIPELINE_DATA_CONTRACT.json
+        run: |
+          Rscript schema_tools/pipeline-contract/validate_fixture_contracts.R
+          Rscript schema_tools/pipeline-contract/validate_stage02_contracts.R
+          Rscript schema_tools/pipeline-contract/validate_stage03_contracts.R
+          Rscript schema_tools/pipeline-contract/validate_stage03_explore_contracts.R
+          Rscript schema_tools/pipeline-contract/validate_stage04_papers_contracts.R
+          Rscript schema_tools/pipeline-contract/validate_pipeline_boundaries.R

--- a/DATA_CONTRACT_CHANGE_CHECKLIST.md
+++ b/DATA_CONTRACT_CHANGE_CHECKLIST.md
@@ -1,0 +1,40 @@
+# Data Contract Change Checklist
+
+Use this checklist for any PR that can alter data consumed downstream by Redivis or `levante-pilots`.
+
+## 1) Contract scope
+
+- Confirm whether this PR changes:
+  - Firestore path patterns
+  - document ID strategy
+  - uniqueness/cardinality assumptions
+  - required field names/types
+- Explicitly call out impacted entities: `surveyResponses`, `assignments`, `runs`, `trials`.
+
+## 2) Required validation commands
+
+- `npm run contract:check`
+- `npx vitest run "__tests__/save-survey-results.contract.test.ts"`
+- `Rscript schema_tools/pipeline-contract/validate_fixture_contracts.R` (in `levante-support`)
+- `Rscript schema_tools/pipeline-contract/validate_stage02_contracts.R` (in `levante-support`)
+- `Rscript schema_tools/pipeline-contract/validate_stage03_contracts.R` (in `levante-support`)
+- `Rscript schema_tools/pipeline-contract/validate_stage03_explore_contracts.R` (in `levante-support`)
+- `Rscript schema_tools/pipeline-contract/validate_stage04_papers_contracts.R` (in `levante-support`)
+
+Attach command output or CI links in the PR.
+
+## 3) Key/cardinality safety
+
+- Confirm `users/{uid}/surveyResponses/{administrationId}` remains one document per `user+administration`.
+- Confirm no changes introduce key collisions or duplicate semantic rows.
+- If key semantics changed, provide migration/backfill plan and rollback plan.
+
+## 4) Rollout strategy
+
+- Describe compatibility behavior for existing data.
+- Note if checks run in warn-mode and when they become blocking.
+
+## 5) Evidence links
+
+- Link `Pipeline Contract Compatibility` workflow run.
+- Link migration ticket/PR (if required).

--- a/functions/levante-admin/src/upsertAdministration.ts
+++ b/functions/levante-admin/src/upsertAdministration.ts
@@ -51,6 +51,32 @@ interface IAdministrationDoc {
   creatorName: string;
 }
 
+const normalizeIdList = (ids: unknown): string[] => {
+  if (!Array.isArray(ids)) return [];
+  return [...new Set(ids)]
+    .filter((id): id is string => typeof id === "string")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+};
+
+const normalizeOrgs = (orgs?: IOrgsList): Required<IOrgsList> => {
+  return {
+    districts: normalizeIdList(orgs?.districts),
+    schools: normalizeIdList(orgs?.schools),
+    classes: normalizeIdList(orgs?.classes),
+    groups: normalizeIdList(orgs?.groups),
+  };
+};
+
+const hasAnyOrgIds = (orgs: Required<IOrgsList>): boolean => {
+  return (
+    orgs.districts.length > 0 ||
+    orgs.schools.length > 0 ||
+    orgs.classes.length > 0 ||
+    orgs.groups.length > 0
+  );
+};
+
 export const upsertAdministrationHandler = async (
   callerAdminUid: string,
   data: UpsertAdministrationData
@@ -79,6 +105,8 @@ export const upsertAdministrationHandler = async (
     legal,
     creatorName,
   } = data as UpsertAdministrationData;
+
+  const normalizedOrgs = normalizeOrgs(orgs);
 
   if (
     !name ||
@@ -135,6 +163,26 @@ export const upsertAdministrationHandler = async (
           );
         }
 
+        const existingData = existingDoc.data() as Partial<IAdministrationDoc>;
+        const existingOrgs = normalizeOrgs({
+          districts: existingData.districts,
+          schools: existingData.schools,
+          classes: existingData.classes,
+          groups: existingData.groups,
+        });
+
+        // Guardrail: if the caller payload doesn't include any valid org IDs (e.g. groups: [null]),
+        // preserve existing org targeting rather than overwriting it.
+        const effectiveOrgs = hasAnyOrgIds(normalizedOrgs)
+          ? normalizedOrgs
+          : existingOrgs;
+        if (!hasAnyOrgIds(normalizedOrgs) && hasAnyOrgIds(existingOrgs)) {
+          logger.warn(
+            "upsertAdministration: preserving existing org targeting (incoming orgs invalid/empty)",
+            { administrationId }
+          );
+        }
+
         // Prepare data for update (merge: true will handle partial updates)
         const updateData: Partial<IAdministrationDoc> = {
           // Use Partial for updates
@@ -142,10 +190,10 @@ export const upsertAdministrationHandler = async (
           publicName: publicName ?? name,
           normalizedName,
           // createdBy should not be updated
-          groups: orgs.groups ?? [],
-          classes: orgs.classes ?? [],
-          schools: orgs.schools ?? [],
-          districts: orgs.districts ?? [],
+          groups: effectiveOrgs.groups,
+          classes: effectiveOrgs.classes,
+          schools: effectiveOrgs.schools,
+          districts: effectiveOrgs.districts,
           // dateCreated should not be updated
           dateOpened: dateOpenedTs,
           dateClosed: dateClosedTs,
@@ -157,17 +205,17 @@ export const upsertAdministrationHandler = async (
           // Explicitly construct org lists for update
           readOrgs: {
             // Re-enabled
-            districts: orgs.districts ?? [],
-            schools: orgs.schools ?? [],
-            classes: orgs.classes ?? [],
-            groups: orgs.groups ?? [],
+            districts: effectiveOrgs.districts,
+            schools: effectiveOrgs.schools,
+            classes: effectiveOrgs.classes,
+            groups: effectiveOrgs.groups,
           },
           minimalOrgs: {
             // Re-enabled
-            districts: orgs.districts ?? [],
-            schools: orgs.schools ?? [],
-            classes: orgs.classes ?? [],
-            groups: orgs.groups ?? [],
+            districts: effectiveOrgs.districts,
+            schools: effectiveOrgs.schools,
+            classes: effectiveOrgs.classes,
+            groups: effectiveOrgs.groups,
           },
           updatedAt: FieldValue.serverTimestamp() as Timestamp,
         };
@@ -192,10 +240,10 @@ export const upsertAdministrationHandler = async (
           normalizedName,
           createdBy: callerAdminUid,
           creatorName: creatorName,
-          groups: orgs.groups ?? [],
-          classes: orgs.classes ?? [],
-          schools: orgs.schools ?? [],
-          districts: orgs.districts ?? [],
+          groups: normalizedOrgs.groups,
+          classes: normalizedOrgs.classes,
+          schools: normalizedOrgs.schools,
+          districts: normalizedOrgs.districts,
           dateCreated: FieldValue.serverTimestamp() as Timestamp,
           dateOpened: dateOpenedTs,
           dateClosed: dateClosedTs,
@@ -204,8 +252,8 @@ export const upsertAdministrationHandler = async (
           tags: tags,
           legal: legal,
           testData: isTestData ?? false,
-          readOrgs: orgs,
-          minimalOrgs: orgs,
+          readOrgs: normalizedOrgs,
+          minimalOrgs: normalizedOrgs,
           siteId,
           createdAt: FieldValue.serverTimestamp() as Timestamp,
           updatedAt: FieldValue.serverTimestamp() as Timestamp,

--- a/scripts/check-pipeline-contract.mjs
+++ b/scripts/check-pipeline-contract.mjs
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const defaultContractPath = path.resolve(repoRoot, '../levante-support/schema_tools/PIPELINE_DATA_CONTRACT.json');
+const contractPath = process.env.PIPELINE_CONTRACT_PATH || defaultContractPath;
+const saveSurveyResultsPath = path.resolve(
+  repoRoot,
+  'functions/levante-admin/src/save-survey-results.ts',
+);
+
+function fail(message) {
+  console.error(`[contract-check] ${message}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(contractPath))
+  fail(`Contract file not found at "${contractPath}". Set PIPELINE_CONTRACT_PATH to override.`);
+
+const contractRaw = fs.readFileSync(contractPath, 'utf8');
+const contract = JSON.parse(contractRaw);
+const surveyContract = contract?.firestoreContracts?.surveyResponses;
+
+if (!surveyContract) fail('Missing firestoreContracts.surveyResponses in contract artifact.');
+if (surveyContract.collectionPath !== 'users/{uid}/surveyResponses/{surveyId}')
+  fail('Unexpected surveyResponses collectionPath in contract.');
+if (surveyContract.documentIdPolicy?.expectedDocIdField !== 'administrationId')
+  fail('surveyResponses expectedDocIdField must be administrationId.');
+if (surveyContract.uniqueness?.maxDocumentsPerScope !== 1)
+  fail('surveyResponses maxDocumentsPerScope must be 1.');
+
+if (!fs.existsSync(saveSurveyResultsPath)) fail(`Source file not found at "${saveSurveyResultsPath}".`);
+
+const source = fs.readFileSync(saveSurveyResultsPath, 'utf8');
+const requiredPatterns = [
+  /surveyResponsesCollection\.doc\(administrationId\)/,
+  /administrationId,\s*\n\s*pageNo,\s*\n\s*updatedAt:/m,
+  /transaction\.set\(surveyRef,\s*updateData,\s*\{\s*merge:\s*true\s*\}\)/,
+  /throw new Error\("administrationId is undefined or null"\)/,
+];
+
+for (const pattern of requiredPatterns) {
+  if (!pattern.test(source)) fail(`Source check failed for pattern: ${pattern}`);
+}
+
+console.log('[contract-check] OK: save-survey-results matches PIPELINE_DATA_CONTRACT invariants.');


### PR DESCRIPTION
Proof of Concept Only -- Just a Prototype

Fixes levante-framework/levante-firebase-functions#44

## What
- Normalize org ID arrays to non-empty strings before writing (drops null/undefined/empty IDs).
- On update, if incoming org targeting normalizes to empty (e.g. groups: [null]), preserve the existing administration org targeting instead of overwriting it.

## Why
We have an intermittent repro where a date-only edit can corrupt administrations.groups/readOrgs/minimalOrgs to [null], which causes assignments to disappear from lists. This backend guardrail prevents that data corruption even if the client submits a malformed org payload.

## Test plan
- Run the gh-0808-open Cypress repro (fast mode) against a hosted env and confirm administrations.groups never becomes [null] after the edit.

Made with [Cursor](https://cursor.com)