### PR TITLE
feat: add callable location upsert/get functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ npm run dev
 npm run emulator:seed
 ```
 
+### Emulator Ports
+
+The current emulator ports are defined in `firebase.json`:
+
+- Auth: `9290`
+- Functions: `5005`
+- Firestore: `8185`
+- Hub: `4402`
+- UI: `4002`
+- Logging: `4502`
+
 
 ### Database Seeding Scripts
 

--- a/firebase.json
+++ b/firebase.json
@@ -19,26 +19,26 @@
   },
   "emulators": {
     "auth": {
-      "port": 9199
+      "port": 9290
     },
     "functions": {
-      "port": 5002
+      "port": 5005
     },
     "firestore": {
-      "port": 8180
+      "port": 8185
     },
     "hub": {
-      "port": 4401
+      "port": 4402
     },
     "tasks": {
       "port": 9899
     },
     "ui": {
       "enabled": true,
-      "port": 4001
+      "port": 4002
     },
     "logging": {
-      "port": 4501
+      "port": 4502
     },
     "singleProjectMode": true
   }

--- a/functions/levante-admin/package.json
+++ b/functions/levante-admin/package.json
@@ -24,6 +24,7 @@
   "license": "Stanford Academic Software License for LEVANTE",
   "main": "lib/src/index.js",
   "dependencies": {
+    "@levante-framework/levante-zod": "^1.0.6",
     "@bdelab/roar-utils": "^1.1.0",
     "@firebase/logger": "^0.4.4",
     "@google-cloud/secret-manager": "^4.2.2",
@@ -35,6 +36,7 @@
     "dotenv": "^16.0.0",
     "firebase-admin": "^13.4.0",
     "firebase-functions": "^6.3.2",
+    "h3-js": "^4.4.0",
     "lodash-es": "^4.17.21",
     "status-code-enum": "^1.0.0",
     "uuid": "^9.0.0"

--- a/functions/levante-admin/src/index.ts
+++ b/functions/levante-admin/src/index.ts
@@ -1036,6 +1036,7 @@ export const upsertAdministration = onCall(async (request) => {
 
 export { completeTask } from "./tasks/completeTask.js";
 export { startTask } from "./tasks/startTask.js";
+export { getLocation, upsertLocation } from "./location/location-functions.js";
 
 export const syncOnRunDocUpdate = onDocumentWritten(
   {

--- a/functions/levante-admin/src/index.ts
+++ b/functions/levante-admin/src/index.ts
@@ -63,15 +63,40 @@ import { upsertAdministrationHandler } from "./upsertAdministration.js";
 import { ORG_COLLECTION_TO_SUBRESOURCE } from "./utils/constants.js";
 import { sanitizeRoles } from "./utils/role-helpers.js";
 
-// initialize 'default' app on Google cloud platform
-admin.initializeApp({
-  credential: admin.applicationDefault(),
+// Surface runtime failures in emulator logs.
+process.on("unhandledRejection", (error) => {
+  logger.error("Unhandled rejection", { error });
+});
+process.on("uncaughtException", (error) => {
+  logger.error("Uncaught exception", { error });
 });
 
+// Initialize default app. Use application default credentials only outside emulators.
+const isEmulator =
+  Boolean(process.env.FUNCTIONS_EMULATOR)
+  || Boolean(process.env.FIRESTORE_EMULATOR_HOST)
+  || Boolean(process.env.FIREBASE_AUTH_EMULATOR_HOST)
+  || Boolean(process.env.FIREBASE_EMULATOR_HUB);
+
+if (isEmulator) {
+  admin.initializeApp();
+} else {
+  admin.initializeApp({
+    credential: admin.applicationDefault(),
+  });
+}
+
 // Initialize permission system (lazy-loads on first use)
-ensurePermissionsLoaded().catch((error) =>
-  logger.error("Error initializing permissions at module load", { error })
-);
+const shouldInitPermissions = !isEmulator && process.env.SKIP_PERMISSION_INIT !== "true";
+if (shouldInitPermissions) {
+  try {
+    void ensurePermissionsLoaded().catch((error) =>
+      logger.error("Error initializing permissions at module load", { error })
+    );
+  } catch (error) {
+    logger.error("Error initializing permissions at module load", { error });
+  }
+}
 
 setGlobalOptions({ timeoutSeconds: 540 });
 

--- a/functions/levante-admin/src/location/location-functions.ts
+++ b/functions/levante-admin/src/location/location-functions.ts
@@ -231,27 +231,37 @@ async function buildLocationDocId(location: LocationRecord): Promise<string> {
 }
 
 export const upsertLocation = onCall(async (request) => {
-  if (!request.auth?.uid) {
-    throw new HttpsError("unauthenticated", "User must be authenticated");
+  logger.info("upsertLocation called", {
+    hasAuth: Boolean(request.auth?.uid),
+    emulator: Boolean(process.env.FIRESTORE_EMULATOR_HOST),
+  });
+  try {
+    if (!request.auth?.uid) {
+      throw new HttpsError("unauthenticated", "User must be authenticated");
+    }
+
+    const requestData = isObject(request.data) ? request.data : {};
+    const locationPayload = requestData.location ?? request.data;
+    const collection = sanitizeCollection(requestData.collection);
+    const parsedLocation = await parseLocation(locationPayload);
+    const docId = await buildLocationDocId(parsedLocation);
+
+    const db = getFirestore();
+    if (process.env.FIRESTORE_EMULATOR_HOST) {
+      db.settings({ ignoreUndefinedProperties: true });
+    }
+    await db.collection(collection).doc(docId).set(parsedLocation, { merge: false });
+
+    return {
+      success: true,
+      id: docId,
+      path: `${collection}/${docId}`,
+      location: parsedLocation,
+    };
+  } catch (error) {
+    logger.error("upsertLocation error", { error });
+    throw error;
   }
-
-  const requestData = isObject(request.data) ? request.data : {};
-  const locationPayload = requestData.location ?? request.data;
-  const collection = sanitizeCollection(requestData.collection);
-  const parsedLocation = await parseLocation(locationPayload);
-  const docId = await buildLocationDocId(parsedLocation);
-
-  await getFirestore()
-    .collection(collection)
-    .doc(docId)
-    .set(parsedLocation, { merge: false });
-
-  return {
-    success: true,
-    id: docId,
-    path: `${collection}/${docId}`,
-    location: parsedLocation,
-  };
 });
 
 export const getLocation = onCall(async (request) => {

--- a/functions/levante-admin/src/location/location-functions.ts
+++ b/functions/levante-admin/src/location/location-functions.ts
@@ -1,0 +1,282 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+import { cellToLatLng, getResolution } from "h3-js";
+
+const DEFAULT_COLLECTION = process.env.LOCATION_FIRESTORE_COLLECTION || "locations";
+const H3_CENTER_EPSILON = 1e-6;
+
+type LatLonSource = "gps" | "h3_center" | "approximate";
+type PopulationSource = "kontur" | "worldpop" | "unknown";
+
+interface LocationRecord {
+  schemaVersion: "location_v1";
+  latLon?: {
+    lat: number;
+    lon: number;
+    source: LatLonSource;
+    blurRadiusMeters?: number;
+  };
+  h3: {
+    scheme: "h3_v1";
+    baseline: {
+      cellId: string;
+      resolution: number;
+    };
+    effective: {
+      cellId: string;
+      resolution: number;
+    };
+    populationThreshold: number;
+  };
+  populationSource?: PopulationSource;
+  computedAt?: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function asPositiveInt(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new HttpsError("invalid-argument", `${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function asH3Resolution(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 15) {
+    throw new HttpsError("invalid-argument", `${label} must be an integer between 0 and 15`);
+  }
+  return value;
+}
+
+function asString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new HttpsError("invalid-argument", `${label} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function sanitizeCollection(rawCollection: unknown): string {
+  if (rawCollection == null) return DEFAULT_COLLECTION;
+  if (typeof rawCollection !== "string" || rawCollection.trim().length === 0) {
+    throw new HttpsError("invalid-argument", "collection must be a non-empty string");
+  }
+  const collection = rawCollection.trim();
+  if (!/^[A-Za-z0-9_-]+$/.test(collection)) {
+    throw new HttpsError("invalid-argument", "collection may only include letters, numbers, underscores, and dashes");
+  }
+  return collection;
+}
+
+function validateIsoDatetime(value: unknown, label: string): string {
+  const out = asString(value, label);
+  if (Number.isNaN(Date.parse(out))) {
+    throw new HttpsError("invalid-argument", `${label} must be an ISO datetime string`);
+  }
+  return out;
+}
+
+function validateLocationFallback(input: unknown): LocationRecord {
+  if (!isObject(input)) {
+    throw new HttpsError("invalid-argument", "location must be an object");
+  }
+  if (input.schemaVersion !== "location_v1") {
+    throw new HttpsError("invalid-argument", "schemaVersion must be location_v1");
+  }
+
+  if (!isObject(input.h3)) {
+    throw new HttpsError("invalid-argument", "h3 is required");
+  }
+  if (input.h3.scheme !== "h3_v1") {
+    throw new HttpsError("invalid-argument", "h3.scheme must be h3_v1");
+  }
+
+  const baseline = input.h3.baseline;
+  const effective = input.h3.effective;
+  if (!isObject(baseline) || !isObject(effective)) {
+    throw new HttpsError("invalid-argument", "h3.baseline and h3.effective are required");
+  }
+
+  const baselineCellId = asString(baseline.cellId, "h3.baseline.cellId");
+  const baselineResolution = asH3Resolution(baseline.resolution, "h3.baseline.resolution");
+  const effectiveCellId = asString(effective.cellId, "h3.effective.cellId");
+  const effectiveResolution = asH3Resolution(effective.resolution, "h3.effective.resolution");
+  const populationThreshold = asPositiveInt(input.h3.populationThreshold, "h3.populationThreshold");
+
+  let baselineFromCell: number;
+  let effectiveFromCell: number;
+  try {
+    baselineFromCell = getResolution(baselineCellId);
+  } catch {
+    throw new HttpsError("invalid-argument", "h3.baseline.cellId is not a valid H3 index");
+  }
+  try {
+    effectiveFromCell = getResolution(effectiveCellId);
+  } catch {
+    throw new HttpsError("invalid-argument", "h3.effective.cellId is not a valid H3 index");
+  }
+
+  if (baselineFromCell !== baselineResolution) {
+    throw new HttpsError("invalid-argument", "h3.baseline.resolution does not match cellId resolution");
+  }
+  if (effectiveFromCell !== effectiveResolution) {
+    throw new HttpsError("invalid-argument", "h3.effective.resolution does not match cellId resolution");
+  }
+  if (effectiveResolution < baselineResolution) {
+    throw new HttpsError("invalid-argument", "h3.effective.resolution must be >= h3.baseline.resolution");
+  }
+
+  const out: LocationRecord = {
+    schemaVersion: "location_v1",
+    h3: {
+      scheme: "h3_v1",
+      baseline: {
+        cellId: baselineCellId,
+        resolution: baselineResolution,
+      },
+      effective: {
+        cellId: effectiveCellId,
+        resolution: effectiveResolution,
+      },
+      populationThreshold,
+    },
+  };
+
+  if (input.populationSource != null) {
+    const source = asString(input.populationSource, "populationSource");
+    if (source !== "kontur" && source !== "worldpop" && source !== "unknown") {
+      throw new HttpsError("invalid-argument", "populationSource must be one of: kontur, worldpop, unknown");
+    }
+    out.populationSource = source;
+  }
+
+  if (input.computedAt != null) {
+    out.computedAt = validateIsoDatetime(input.computedAt, "computedAt");
+  }
+
+  if (input.latLon != null) {
+    if (!isObject(input.latLon)) {
+      throw new HttpsError("invalid-argument", "latLon must be an object");
+    }
+    const lat = input.latLon.lat;
+    const lon = input.latLon.lon;
+    if (typeof lat !== "number" || lat < -90 || lat > 90) {
+      throw new HttpsError("invalid-argument", "latLon.lat must be a number between -90 and 90");
+    }
+    if (typeof lon !== "number" || lon < -180 || lon > 180) {
+      throw new HttpsError("invalid-argument", "latLon.lon must be a number between -180 and 180");
+    }
+
+    const source = asString(input.latLon.source, "latLon.source");
+    if (source !== "gps" && source !== "h3_center" && source !== "approximate") {
+      throw new HttpsError("invalid-argument", "latLon.source must be one of: gps, h3_center, approximate");
+    }
+
+    const latLon: LocationRecord["latLon"] = { lat, lon, source };
+    if (source === "approximate") {
+      if (
+        typeof input.latLon.blurRadiusMeters !== "number" ||
+        !Number.isFinite(input.latLon.blurRadiusMeters) ||
+        input.latLon.blurRadiusMeters <= 0
+      ) {
+        throw new HttpsError("invalid-argument", "latLon.blurRadiusMeters is required when source is approximate");
+      }
+      latLon.blurRadiusMeters = input.latLon.blurRadiusMeters;
+    }
+
+    if (source === "h3_center") {
+      const [centerLat, centerLon] = cellToLatLng(effectiveCellId);
+      if (
+        Math.abs(centerLat - lat) > H3_CENTER_EPSILON ||
+        Math.abs(centerLon - lon) > H3_CENTER_EPSILON
+      ) {
+        throw new HttpsError(
+          "invalid-argument",
+          "latLon must match effective H3 center when source is h3_center"
+        );
+      }
+    }
+    out.latLon = latLon;
+  }
+
+  return out;
+}
+
+async function parseLocation(location: unknown): Promise<LocationRecord> {
+  try {
+    const sdk: any = await import("@levante-framework/levante-zod");
+    if (sdk?.LocationSchema?.parse) {
+      return sdk.LocationSchema.parse(location) as LocationRecord;
+    }
+    logger.warn("LocationSchema not found in @levante-framework/levante-zod, using fallback validator");
+    return validateLocationFallback(location);
+  } catch (error) {
+    logger.warn("Could not import @levante-framework/levante-zod, using fallback validator", { error });
+    return validateLocationFallback(location);
+  }
+}
+
+async function buildLocationDocId(location: LocationRecord): Promise<string> {
+  try {
+    const sdk: any = await import("@levante-framework/levante-zod");
+    if (typeof sdk?.locationDocId === "function") {
+      return sdk.locationDocId(location);
+    }
+  } catch (_) {
+    // Ignore and use fallback below.
+  }
+  return `h3:${location.h3.effective.cellId}:t:${location.h3.populationThreshold}:v1`;
+}
+
+export const upsertLocation = onCall(async (request) => {
+  if (!request.auth?.uid) {
+    throw new HttpsError("unauthenticated", "User must be authenticated");
+  }
+
+  const requestData = isObject(request.data) ? request.data : {};
+  const locationPayload = requestData.location ?? request.data;
+  const collection = sanitizeCollection(requestData.collection);
+  const parsedLocation = await parseLocation(locationPayload);
+  const docId = await buildLocationDocId(parsedLocation);
+
+  await getFirestore()
+    .collection(collection)
+    .doc(docId)
+    .set(parsedLocation, { merge: false });
+
+  return {
+    success: true,
+    id: docId,
+    path: `${collection}/${docId}`,
+    location: parsedLocation,
+  };
+});
+
+export const getLocation = onCall(async (request) => {
+  if (!request.auth?.uid) {
+    throw new HttpsError("unauthenticated", "User must be authenticated");
+  }
+
+  const requestData = isObject(request.data) ? request.data : {};
+  const docId = asString(requestData.docId, "docId");
+  const collection = sanitizeCollection(requestData.collection);
+
+  const snap = await getFirestore()
+    .collection(collection)
+    .doc(docId)
+    .get();
+
+  if (!snap.exists) {
+    throw new HttpsError("not-found", `Location ${docId} not found`);
+  }
+
+  const location = await parseLocation(snap.data());
+  return {
+    success: true,
+    id: docId,
+    path: `${collection}/${docId}`,
+    location,
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@bdelab/roar-utils": "^1.1.0",
         "@firebase/logger": "^0.4.4",
         "@google-cloud/secret-manager": "^4.2.2",
+        "@levante-framework/levante-zod": "^1.0.6",
         "@levante-framework/permissions-core": "^1.1.2",
         "axios": "^1.4.0",
         "axios-oauth-1.0a": "^0.3.6",
@@ -49,6 +50,7 @@
         "dotenv": "^16.0.0",
         "firebase-admin": "^13.4.0",
         "firebase-functions": "^6.3.2",
+        "h3-js": "^4.4.0",
         "lodash-es": "^4.17.21",
         "status-code-enum": "^1.0.0",
         "uuid": "^9.0.0"
@@ -2977,6 +2979,24 @@
     "node_modules/@levante-firebase-functions/levante-admin": {
       "resolved": "functions/levante-admin",
       "link": true
+    },
+    "node_modules/@levante-framework/levante-zod": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.0.6.tgz",
+      "integrity": "sha512-fjpwp/fvE24Rf2F4xrmVTLDBty8kPdncy9FdhwbiMZIIX2isajM/t4bMO5lv0V7SSYY2C7OGRQexlYmr/QCUHw==",
+      "license": "ISC",
+      "dependencies": {
+        "zod": "^4.0.5"
+      }
+    },
+    "node_modules/@levante-framework/levante-zod/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/@levante-framework/permissions-core": {
       "version": "1.1.2",
@@ -8611,6 +8631,17 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/h3-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
+      "integrity": "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
       }
     },
     "node_modules/has-flag": {


### PR DESCRIPTION
## Summary
- add authenticated callable functions in `levante-admin` for location upsert and retrieval: `upsertLocation` and `getLocation`
- enforce H3-aware location validation (including baseline/effective resolution checks, approximate blur requirements, and H3 center consistency)
- use deterministic location document IDs with shared `@levante-framework/levante-zod` integration and a local fallback validator for compatibility
- export the new callables from `src/index.ts` and add required dependencies (`@levante-framework/levante-zod`, `h3-js`)
- make admin init emulator-aware, guard permissions initialization, add request logging, and align emulator ports

NOTE: I think this is functionally self-contained, but it may duplicate some utility functions we already have in our function library. I'm not familiar enough to know if any the do.

## Test plan
- [x] `cd functions/levante-admin && npm install`
- [x] `cd functions/levante-admin && npm run build`
- [x] `firebase emulators:start --only auth,functions,firestore --project hs-levante-admin-dev`
- [x] invoke `upsertLocation` via location-selection debug UI and confirm doc in emulator