### PR TITLE
Super/site admins cannot delete other admins

### DIFF
--- a/functions/levante-admin/src/users/update-administrator.ts
+++ b/functions/levante-admin/src/users/update-administrator.ts
@@ -220,13 +220,10 @@ export const removeAdministratorRoles = async ({
 
     const roleRemoved = currentRoles.find((r) => r.siteId === siteId);
     const now = FieldValue.serverTimestamp();
-    transaction.update(context.adminUserDocRef, {
-      roles: remainingRoles,
-      updatedAt: now,
-    });
+    const districtDocRef = db.collection("districts").doc(siteId);
+    let districtAdministrators: Array<Record<string, unknown>> | null = null;
 
     if (roleRemoved?.role !== ROLES.SUPER_ADMIN) {
-      const districtDocRef = db.collection("districts").doc(siteId);
       const districtSnapshot = await transaction.get(districtDocRef);
 
       if (!districtSnapshot.exists) {
@@ -248,7 +245,7 @@ export const removeAdministratorRoles = async ({
           entry?.adminUid !== context.adminUid || entry.siteId !== siteId
       );
 
-      const updatedAdministrators = existingEntry
+      districtAdministrators = existingEntry
         ? [
             ...otherAdministrators,
             {
@@ -261,9 +258,16 @@ export const removeAdministratorRoles = async ({
             },
           ]
         : otherAdministrators;
+    }
 
+    transaction.update(context.adminUserDocRef, {
+      roles: remainingRoles,
+      updatedAt: now,
+    });
+
+    if (districtAdministrators !== null) {
       transaction.update(districtDocRef, {
-        administrators: updatedAdministrators,
+        administrators: districtAdministrators,
         updatedAt: now,
       });
     }


### PR DESCRIPTION
## Proposed changes

Basically, the function responsible for removing admins had a mix of Firestore reads and writes. So the fix was just to re-order the transactions.


https://github.com/user-attachments/assets/627cd3be-232f-4bc9-9920-d08e026a6f9d



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
