### PR TITLE
workflow to reattach assignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,12 @@ node_modules/
 
 # dotenv environment variables file
 .env
+.env.*
+**/.env
+**/.env.*
+
+# Local service-account credential files
+/creds/
 
 .idea/
 

--- a/functions/local/package.json
+++ b/functions/local/package.json
@@ -35,7 +35,9 @@
     "inspect-admin-access": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/inspect-admin-access.ts",
     "list-superadmins": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/list-superadmins.ts",
     "rebuild-custom-claims": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/rebuild-custom-claims.ts",
-    "set-superadmin": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/set-superadmin.ts"
+    "set-superadmin": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/set-superadmin.ts",
+    "identify-detached-administrations": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/identify-detached-administrations.ts",
+    "reattach-administrations": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/reattach-administrations.ts"
   },
   "author": "Adam Richie-Halford <richiehalford@gmail.com> (https://richiehalford.org/)",
   "engines": {

--- a/functions/local/src/identify-detached-administrations.ts
+++ b/functions/local/src/identify-detached-administrations.ts
@@ -1,0 +1,437 @@
+// Import filesystem utilities for writing CSV and reading env file.
+import * as fs from "fs";
+// Import path utilities for resolving output paths.
+import * as path from "path";
+// Import yargs for CLI argument parsing.
+import yargs from "yargs";
+// Import shared local admin initialization utility.
+import { initAdmin } from "./utils/init-admin.js";
+
+// Define accepted CLI arguments for the script.
+interface Args {
+  // Which Firebase project should be scanned.
+  environment: "dev" | "prod";
+  // Optional path to a local env file to load before reading process.env.
+  envFile: string;
+  // Output CSV file path for detached administrations.
+  outputFile: string;
+  // Optional limit for smoke testing this script on fewer administration docs.
+  testSize?: number;
+}
+
+// Parse command line arguments.
+const argv = yargs(process.argv.slice(2))
+  .options({
+    environment: {
+      alias: "e",
+      description: "Environment to run against",
+      choices: ["dev", "prod"] as const,
+      default: "dev" as const,
+    },
+    envFile: {
+      alias: "f",
+      description:
+        "Path to local env file containing LEVANTE_ADMIN_FIREBASE_CREDENTIALS",
+      type: "string",
+      default: ".env.local",
+    },
+    outputFile: {
+      alias: "o",
+      description: "CSV output path",
+      type: "string",
+      default: "detached-administrations-report.csv",
+    },
+    testSize: {
+      alias: "t",
+      description: "Limit number of administrations processed",
+      type: "number",
+    },
+  })
+  .help("help")
+  .alias("help", "h").argv as Args;
+
+// Convert unknown value into a normalized string array.
+function ensureStringArray(value: unknown): string[] {
+  // Non-array values should be treated as empty.
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  // Keep non-empty trimmed strings only.
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+// Escape a value for CSV format.
+function toCsvCell(value: string): string {
+  // Double-up existing quotes to preserve literal quotes.
+  const escaped = value.replace(/"/g, '""');
+  // Wrap every value in quotes for safety.
+  return `"${escaped}"`;
+}
+
+// Join a list into a single pipe-delimited cell string.
+function joinCell(values: string[]): string {
+  // Return a stable delimiter format expected by analysts.
+  return values.join("|");
+}
+
+// Map orgType to top-level collection name.
+function resolveCollectionFromOrgType(orgType: string): string | null {
+  // Normalize spacing and case just in case.
+  const normalized = orgType.trim().toLowerCase();
+  // Handle singular and plural values seen across code paths.
+  if (normalized === "district" || normalized === "districts") {
+    return "districts";
+  }
+  if (normalized === "school" || normalized === "schools") {
+    return "schools";
+  }
+  if (normalized === "class" || normalized === "classes") {
+    return "classes";
+  }
+  if (normalized === "group" || normalized === "groups") {
+    return "groups";
+  }
+  // Unknown types are unresolved.
+  return null;
+}
+
+// Resolve an org display name using orgType + orgId.
+async function getOrgName(
+  db: FirebaseFirestore.Firestore,
+  cache: Map<string, string>,
+  orgType: string,
+  orgId: string,
+): Promise<string> {
+  // Build a cache key for this lookup.
+  const cacheKey = `${orgType}:${orgId}`;
+  // Serve cached name when available.
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey) as string;
+  }
+
+  // Resolve collection name from orgType value.
+  const collectionName = resolveCollectionFromOrgType(orgType);
+  // Return placeholder for unsupported orgType.
+  if (!collectionName) {
+    const fallback = `UNKNOWN_ORG_TYPE(${orgType})`;
+    cache.set(cacheKey, fallback);
+    return fallback;
+  }
+
+  // Load organization document.
+  const orgDoc = await db.collection(collectionName).doc(orgId).get();
+  // Return placeholder if document is missing.
+  if (!orgDoc.exists) {
+    const fallback = `MISSING_ORG(${orgId})`;
+    cache.set(cacheKey, fallback);
+    return fallback;
+  }
+
+  // Read org data payload.
+  const orgData = orgDoc.data();
+  // Resolve human-readable name.
+  const name =
+    typeof orgData?.name === "string" && orgData.name.trim().length > 0
+      ? orgData.name.trim()
+      : `UNNAMED_ORG(${orgId})`;
+
+  // Cache and return.
+  cache.set(cacheKey, name);
+  return name;
+}
+
+// Resolve site (district) name from siteId.
+async function getSiteName(
+  db: FirebaseFirestore.Firestore,
+  cache: Map<string, string>,
+  siteId: string,
+): Promise<string> {
+  // Handle missing siteId explicitly.
+  if (!siteId) {
+    return "";
+  }
+  // Use cache when possible.
+  if (cache.has(siteId)) {
+    return cache.get(siteId) as string;
+  }
+  // Fetch district doc by siteId.
+  const siteDoc = await db.collection("districts").doc(siteId).get();
+  // Use explicit marker if district doc is missing.
+  if (!siteDoc.exists) {
+    const fallback = `MISSING_SITE(${siteId})`;
+    cache.set(siteId, fallback);
+    return fallback;
+  }
+  // Extract district name.
+  const siteData = siteDoc.data();
+  const siteName =
+    typeof siteData?.name === "string" && siteData.name.trim().length > 0
+      ? siteData.name.trim()
+      : `UNNAMED_SITE(${siteId})`;
+  // Cache and return.
+  cache.set(siteId, siteName);
+  return siteName;
+}
+
+// Determine whether top-level assignment org fields are all empty.
+function isDetachedAdministration(data: FirebaseFirestore.DocumentData): boolean {
+  // Normalize each top-level org list.
+  const districts = ensureStringArray(data.districts);
+  const schools = ensureStringArray(data.schools);
+  const classes = ensureStringArray(data.classes);
+  const groups = ensureStringArray(data.groups);
+  // Flag detached administrations where all four are empty.
+  return (
+    districts.length === 0 &&
+    schools.length === 0 &&
+    classes.length === 0 &&
+    groups.length === 0
+  );
+}
+
+// Define one CSV row shape for detached administrations.
+interface DetachedAdministrationRow {
+  administrationId: string;
+  administrationName: string;
+  siteId: string;
+  siteName: string;
+  dateOpened: string;
+  dateClosed: string;
+  createdBy: string;
+  assignedOrgsIds: string[];
+  assignedOrgTypes: string[];
+  assignedOrgNames: string[];
+}
+
+// Convert Firestore timestamp-like values to ISO date strings.
+function formatDateValue(value: unknown): string {
+  // Return empty string for nullish values.
+  if (!value) {
+    return "";
+  }
+
+  // Handle Date instances.
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  // Handle Firestore Timestamp objects that expose toDate().
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "toDate" in value &&
+    typeof (value as { toDate: () => Date }).toDate === "function"
+  ) {
+    return (value as { toDate: () => Date }).toDate().toISOString();
+  }
+
+  // Preserve string values as-is.
+  if (typeof value === "string") {
+    return value.trim();
+  }
+
+  // Fallback to string representation for other primitive/object values.
+  return String(value);
+}
+
+// Traverse administrations and collect detached ones.
+async function collectDetachedAdministrations(
+  db: FirebaseFirestore.Firestore,
+): Promise<DetachedAdministrationRow[]> {
+  // Build query for all administrations or limited sample.
+  let query: FirebaseFirestore.Query = db
+    .collection("administrations")
+    .select(
+      "name",
+      "siteId",
+      "districts",
+      "schools",
+      "classes",
+      "groups",
+      "dateOpened",
+      "dateClosed",
+      "createdBy",
+    );
+
+  // Apply optional test limit.
+  if (argv.testSize) {
+    query = query.limit(argv.testSize);
+  }
+
+  // Execute query once.
+  const snapshot = await query.get();
+  // Log query scope.
+  console.log(`Found ${snapshot.size} administration documents to inspect.`);
+
+  // Prepare output rows.
+  const rows: DetachedAdministrationRow[] = [];
+  // Cache district names for repeated siteIds.
+  const siteNameCache = new Map<string, string>();
+  // Cache org names for repeated org lookups.
+  const orgNameCache = new Map<string, string>();
+
+  // Iterate each administration document.
+  for (const administrationDoc of snapshot.docs) {
+    // Read administration payload.
+    const administrationData = administrationDoc.data();
+    // Skip non-detached administrations.
+    if (!isDetachedAdministration(administrationData)) {
+      continue;
+    }
+
+    // Resolve top-level administration id and name.
+    const administrationId = administrationDoc.id;
+    const administrationName =
+      typeof administrationData.name === "string" &&
+      administrationData.name.trim().length > 0
+        ? administrationData.name.trim()
+        : "";
+    // Resolve site id from top-level field.
+    const siteId =
+      typeof administrationData.siteId === "string" &&
+      administrationData.siteId.trim().length > 0
+        ? administrationData.siteId.trim()
+        : "";
+    // Resolve top-level dateOpened value.
+    const dateOpened = formatDateValue(administrationData.dateOpened);
+    // Resolve top-level dateClosed value.
+    const dateClosed = formatDateValue(administrationData.dateClosed);
+    // Resolve top-level createdBy value.
+    const createdBy =
+      typeof administrationData.createdBy === "string" &&
+      administrationData.createdBy.trim().length > 0
+        ? administrationData.createdBy.trim()
+        : "";
+    // Resolve site name via districts collection.
+    const siteName = await getSiteName(db, siteNameCache, siteId);
+
+    // Load assignedOrgs subcollection for this administration.
+    const assignedOrgsSnapshot = await administrationDoc.ref
+      .collection("assignedOrgs")
+      .get();
+
+    // Accumulate assigned org ids, types, and names.
+    const assignedOrgsIds: string[] = [];
+    const assignedOrgTypes: string[] = [];
+    const assignedOrgNames: string[] = [];
+
+    // Iterate through assignedOrg docs.
+    for (const assignedOrgDoc of assignedOrgsSnapshot.docs) {
+      // Read assignedOrg data.
+      const assignedOrgData = assignedOrgDoc.data();
+      // Prefer explicit orgId field; fallback to doc id.
+      const orgId =
+        typeof assignedOrgData.orgId === "string" &&
+        assignedOrgData.orgId.trim().length > 0
+          ? assignedOrgData.orgId.trim()
+          : assignedOrgDoc.id;
+      // Read orgType field or mark unknown.
+      const orgType =
+        typeof assignedOrgData.orgType === "string" &&
+        assignedOrgData.orgType.trim().length > 0
+          ? assignedOrgData.orgType.trim()
+          : "UNKNOWN_ORG_TYPE";
+      // Resolve org name from orgType + orgId.
+      const orgName = await getOrgName(db, orgNameCache, orgType, orgId);
+
+      // Push values preserving document order.
+      assignedOrgsIds.push(orgId);
+      assignedOrgTypes.push(orgType);
+      assignedOrgNames.push(orgName);
+    }
+
+    // Append report row.
+    rows.push({
+      administrationId,
+      administrationName,
+      siteId,
+      siteName,
+      dateOpened,
+      dateClosed,
+      createdBy,
+      assignedOrgsIds,
+      assignedOrgTypes,
+      assignedOrgNames,
+    });
+  }
+
+  // Return final detached administration list.
+  return rows;
+}
+
+// Persist detached administration rows to CSV.
+function writeCsv(rows: DetachedAdministrationRow[]): void {
+  // Resolve output path relative to current working directory.
+  const outputPath = path.resolve(process.cwd(), argv.outputFile);
+  // Build CSV header line.
+  const header = [
+    "administrationId",
+    "administrationName",
+    "siteId",
+    "siteName",
+    "dateOpened",
+    "dateClosed",
+    "createdBy",
+    "assignedOrgsIds",
+    "assignedOrgTypes",
+    "assignedOrgNames",
+  ].join(",");
+
+  // Convert each row to CSV-safe columns.
+  const csvLines = rows.map((row) =>
+    [
+      toCsvCell(row.administrationId),
+      toCsvCell(row.administrationName),
+      toCsvCell(row.siteId),
+      toCsvCell(row.siteName),
+      toCsvCell(row.dateOpened),
+      toCsvCell(row.dateClosed),
+      toCsvCell(row.createdBy),
+      toCsvCell(joinCell(row.assignedOrgsIds)),
+      toCsvCell(joinCell(row.assignedOrgTypes)),
+      toCsvCell(joinCell(row.assignedOrgNames)),
+    ].join(","),
+  );
+
+  // Join full CSV content.
+  const csvContent = [header, ...csvLines].join("\n");
+  // Write file atomically.
+  fs.writeFileSync(outputPath, csvContent, "utf8");
+
+  // Print completion message.
+  console.log(`\n✅ CSV report written to: ${outputPath}`);
+  console.log(`Detached administrations found: ${rows.length}`);
+}
+
+// Main script entrypoint.
+async function main() {
+  // Print startup context.
+  console.log(
+    `Running detached administration detector in ${argv.environment} environment`,
+  );
+  console.log(`Using env file: ${argv.envFile}`);
+  console.log(`Output CSV: ${argv.outputFile}`);
+
+  // Connect to Firebase.
+  console.log("Initializing Firebase connection...");
+  const { db } = await initAdmin({
+    environment: argv.environment,
+    envFile: argv.envFile,
+    appName: "admin",
+  });
+  console.log("Firebase connection established.");
+
+  // Scan administrations and build report rows.
+  const rows = await collectDetachedAdministrations(db);
+  // Write rows to CSV.
+  writeCsv(rows);
+}
+
+// Execute script and fail with non-zero code on error.
+main().catch((error) => {
+  console.error("Fatal script error:", error);
+  process.exit(1);
+});

--- a/functions/local/src/reattach-administrations.ts
+++ b/functions/local/src/reattach-administrations.ts
@@ -1,0 +1,323 @@
+import * as fs from "fs";
+import * as path from "path";
+import yargs from "yargs";
+import Papa from "papaparse";
+import { initAdmin } from "./utils/init-admin.js";
+import { upsertAdministrationHandler } from "../../levante-admin/src/upsertAdministration.js";
+
+interface Args {
+  environment: "dev" | "prod";
+  envFile: string;
+  inputFile: string;
+  outputFile: string;
+  dryRun: boolean;
+  testSize?: number;
+}
+
+interface CsvRow {
+  administrationId: string;
+  districts: string;
+  schools: string;
+  class: string;
+  groups: string;
+}
+
+interface OrgList {
+  districts: string[];
+  schools: string[];
+  classes: string[];
+  groups: string[];
+}
+
+interface ReattachResult {
+  administrationId: string;
+  status: "updated" | "dry-run" | "error";
+  message: string;
+}
+
+const argv = yargs(process.argv.slice(2))
+  .options({
+    environment: {
+      alias: "e",
+      description: "Environment to run against",
+      choices: ["dev", "prod"] as const,
+      default: "dev" as const,
+    },
+    envFile: {
+      alias: "f",
+      description: "Path to env file",
+      type: "string",
+      default: ".env.local",
+    },
+    inputFile: {
+      alias: "i",
+      description: "Input CSV with administrationId,targetOrgs",
+      type: "string",
+      default: "detached-admins-to-reattach.csv",
+    },
+    outputFile: {
+      alias: "o",
+      description: "Output CSV with operation status",
+      type: "string",
+      default: "detached-admins-reattach-results.csv",
+    },
+    dryRun: {
+      alias: "d",
+      description: "Validate and print without mutating data",
+      type: "boolean",
+      default: true,
+    },
+    testSize: {
+      alias: "t",
+      description: "Limit number of rows to process",
+      type: "number",
+    },
+  })
+  .help("help")
+  .alias("help", "h").argv as Args;
+
+function parseCsv(inputFilePath: string): CsvRow[] {
+  const resolvedPath = path.resolve(process.cwd(), inputFilePath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Input CSV file not found: ${resolvedPath}`);
+  }
+
+  const csvText = fs.readFileSync(resolvedPath, "utf8");
+  const parsed = Papa.parse<Record<string, string>>(csvText, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  if (parsed.errors.length > 0) {
+    const message = parsed.errors.map((error) => error.message).join("; ");
+    throw new Error(`Failed parsing CSV: ${message}`);
+  }
+
+  return parsed.data.map((row) => {
+    const administrationId =
+      row.administrationId?.trim() || row.administrationID?.trim() || "";
+    const districts = row.districts?.trim() || "";
+    const schools = row.schools?.trim() || "";
+    const classValue = row.class?.trim() || row.classes?.trim() || "";
+    const groups = row.groups?.trim() || "";
+    return {
+      administrationId,
+      districts,
+      schools,
+      class: classValue,
+      groups,
+    };
+  });
+}
+
+function ensureStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0),
+    ),
+  );
+}
+
+function parseOrgCell(rawValue: string): string[] {
+  if (!rawValue.trim()) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      rawValue
+        .split("|")
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0),
+    ),
+  );
+}
+
+function parseTargetOrgs(row: CsvRow): OrgList {
+  const parsed = {
+    districts: parseOrgCell(row.districts),
+    schools: parseOrgCell(row.schools),
+    classes: parseOrgCell(row.class),
+    groups: parseOrgCell(row.groups),
+  };
+
+  return {
+    districts: ensureStringArray(parsed.districts),
+    schools: ensureStringArray(parsed.schools),
+    classes: ensureStringArray(parsed.classes),
+    groups: ensureStringArray(parsed.groups),
+  };
+}
+
+function formatDateField(value: unknown): string {
+  if (!value) {
+    return "";
+  }
+
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "toDate" in value &&
+    typeof (value as { toDate: () => Date }).toDate === "function"
+  ) {
+    return (value as { toDate: () => Date }).toDate().toISOString();
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return String(value);
+}
+
+function toCsvCell(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function writeResults(outputFile: string, results: ReattachResult[]): void {
+  const outputPath = path.resolve(process.cwd(), outputFile);
+  const header = ["administrationId", "status", "message"].join(",");
+  const lines = results.map((result) =>
+    [
+      toCsvCell(result.administrationId),
+      toCsvCell(result.status),
+      toCsvCell(result.message),
+    ].join(","),
+  );
+  fs.writeFileSync(outputPath, [header, ...lines].join("\n"), "utf8");
+  console.log(`\n✅ Results written to ${outputPath}`);
+}
+
+async function main() {
+  console.log(
+    `Running reattach administrations in ${argv.environment} environment`,
+  );
+  console.log(`Dry run mode: ${argv.dryRun ? "ON" : "OFF"}`);
+  console.log(`Input file: ${argv.inputFile}`);
+
+  const { db } = await initAdmin({
+    environment: argv.environment,
+    envFile: argv.envFile,
+    appName: "admin",
+    alsoInitializeDefaultApp: true,
+  });
+
+  const inputRows = parseCsv(argv.inputFile);
+  const rows = argv.testSize ? inputRows.slice(0, argv.testSize) : inputRows;
+  const results: ReattachResult[] = [];
+
+  for (const row of rows) {
+    const administrationId = row.administrationId.trim();
+    if (!administrationId) {
+      results.push({
+        administrationId: "",
+        status: "error",
+        message: "Missing administrationId in CSV row",
+      });
+      continue;
+    }
+
+    try {
+      const targetOrgs = parseTargetOrgs(row);
+      const hasAnyTargetOrg =
+        targetOrgs.districts.length > 0 ||
+        targetOrgs.schools.length > 0 ||
+        targetOrgs.classes.length > 0 ||
+        targetOrgs.groups.length > 0;
+
+      if (!hasAnyTargetOrg) {
+        throw new Error("No target organizations parsed from targetOrgs");
+      }
+
+      const adminDoc = await db
+        .collection("administrations")
+        .doc(administrationId)
+        .get();
+      if (!adminDoc.exists) {
+        throw new Error("Administration not found");
+      }
+
+      const data = adminDoc.data();
+      if (!data) {
+        throw new Error("Administration data was empty");
+      }
+
+      const payload = {
+        administrationId,
+        name: typeof data.name === "string" ? data.name : "",
+        publicName: typeof data.publicName === "string" ? data.publicName : "",
+        normalizedName:
+          typeof data.normalizedName === "string" ? data.normalizedName : "",
+        assessments: Array.isArray(data.assessments) ? data.assessments : [],
+        dateOpen: formatDateField(data.dateOpened),
+        dateClose: formatDateField(data.dateClosed),
+        sequential: typeof data.sequential === "boolean" ? data.sequential : true,
+        orgs: targetOrgs,
+        tags: Array.isArray(data.tags) ? data.tags : [],
+        isTestData: Boolean(data.testData),
+        legal: data.legal,
+        creatorName:
+          typeof data.creatorName === "string" ? data.creatorName : "Unknown",
+        siteId: typeof data.siteId === "string" ? data.siteId : "",
+      };
+
+      const callerUid =
+        typeof data.createdBy === "string" && data.createdBy.length > 0
+          ? data.createdBy
+          : "local-script";
+
+      if (argv.dryRun) {
+        results.push({
+          administrationId,
+          status: "dry-run",
+          message: `Validated payload. Target org counts: d=${targetOrgs.districts.length}, s=${targetOrgs.schools.length}, c=${targetOrgs.classes.length}, g=${targetOrgs.groups.length}`,
+        });
+        continue;
+      }
+
+      await upsertAdministrationHandler(callerUid, payload);
+
+      results.push({
+        administrationId,
+        status: "updated",
+        message: "upsertAdministration completed",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({
+        administrationId,
+        status: "error",
+        message,
+      });
+    }
+  }
+
+  writeResults(argv.outputFile, results);
+
+  const updatedCount = results.filter((result) => result.status === "updated").length;
+  const dryRunCount = results.filter((result) => result.status === "dry-run").length;
+  const errorCount = results.filter((result) => result.status === "error").length;
+
+  console.log("\n" + "=".repeat(60));
+  console.log("REATTACH SUMMARY");
+  console.log("=".repeat(60));
+  console.log(`Total rows processed: ${results.length}`);
+  console.log(`Updated: ${updatedCount}`);
+  console.log(`Dry-run validated: ${dryRunCount}`);
+  console.log(`Errors: ${errorCount}`);
+  console.log("=".repeat(60));
+}
+
+main().catch((error) => {
+  console.error("Fatal script error:", error);
+  process.exit(1);
+});

--- a/functions/local/src/utils/init-admin.ts
+++ b/functions/local/src/utils/init-admin.ts
@@ -1,0 +1,289 @@
+// Import Firebase Admin app helpers.
+import * as admin from "firebase-admin/app";
+// Import Firestore accessor bound to a specific app.
+import { getFirestore } from "firebase-admin/firestore";
+// Import filesystem helpers for env file reading.
+import * as fs from "fs";
+// Import path helpers for resolving local file paths.
+import * as path from "path";
+// Import file URL helper to resolve this module location.
+import { fileURLToPath } from "url";
+// Import createRequire to load modules from specific package roots.
+import { createRequire } from "module";
+
+// Define the accepted local environments for admin project selection.
+type AdminEnvironment = "dev" | "prod";
+
+// Define configuration options for initialization.
+interface InitAdminOptions {
+  // Target environment to determine Firebase project id.
+  environment: AdminEnvironment;
+  // Optional path to an env file that contains credentials variable.
+  envFile?: string;
+  // Optional Firebase app name to avoid collisions.
+  appName?: string;
+  // Optionally initialize the Firebase default app as well.
+  alsoInitializeDefaultApp?: boolean;
+}
+
+// Define return shape used by one-off scripts.
+interface InitializedAdmin {
+  // Initialized Firebase app instance.
+  app: admin.App;
+  // Firestore instance bound to the initialized app.
+  db: FirebaseFirestore.Firestore;
+}
+
+// Name of environment variable containing dev credential JSON path.
+const ADMIN_DEV_CREDENTIAL_ENV = "LEVANTE_ADMIN_DEV_FIREBASE_CREDENTIALS";
+// Name of environment variable containing prod credential JSON path.
+const ADMIN_PROD_CREDENTIAL_ENV = "LEVANTE_ADMIN_PROD_FIREBASE_CREDENTIALS";
+// Backward-compatible fallback env var used by older scripts.
+const ADMIN_FALLBACK_CREDENTIAL_ENV = "LEVANTE_ADMIN_FIREBASE_CREDENTIALS";
+
+// Parse a simple KEY=VALUE env file and set process.env for missing keys.
+function loadEnvFile(envFilePath: string): void {
+  // Resolve relative path from current working directory.
+  const resolvedPath = path.resolve(process.cwd(), envFilePath);
+  // Exit quickly when file does not exist.
+  if (!fs.existsSync(resolvedPath)) {
+    return;
+  }
+
+  // Read env file as text.
+  const fileContents = fs.readFileSync(resolvedPath, "utf8");
+  // Split into lines for parsing.
+  const lines = fileContents.split(/\r?\n/);
+
+  // Process each line in the env file.
+  for (const line of lines) {
+    // Ignore whitespace-only lines.
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    // Ignore comments.
+    if (trimmed.startsWith("#")) {
+      continue;
+    }
+    // Find first equals sign.
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    // Parse key and value fragments.
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+
+    // Remove wrapping quotes when present.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    // Preserve already-exported shell values.
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+
+// Resolve likely paths for an env file across local and repo roots.
+function getEnvFileCandidates(envFile: string): string[] {
+  // Resolve current module directory in ESM context.
+  const currentFilePath = fileURLToPath(import.meta.url);
+  const currentDir = path.dirname(currentFilePath);
+  // Resolve local package root (functions/local).
+  const localRoot = path.resolve(currentDir, "../../");
+  // Resolve repository root (levante-firebase-functions).
+  const repoRoot = path.resolve(currentDir, "../../../../");
+
+  // Build candidate list in priority order.
+  const candidates = new Set<string>();
+
+  // If user passed an absolute path, try that directly first.
+  if (path.isAbsolute(envFile)) {
+    candidates.add(envFile);
+  } else {
+    // Try relative to current process directory.
+    candidates.add(path.resolve(process.cwd(), envFile));
+    // Try relative to local package root.
+    candidates.add(path.resolve(localRoot, envFile));
+    // Try relative to repo root.
+    candidates.add(path.resolve(repoRoot, envFile));
+  }
+
+  // Always include common defaults so top-level .env is detected.
+  candidates.add(path.resolve(localRoot, ".env.local"));
+  candidates.add(path.resolve(localRoot, ".env"));
+  candidates.add(path.resolve(repoRoot, ".env.local"));
+  candidates.add(path.resolve(repoRoot, ".env"));
+
+  return Array.from(candidates);
+}
+
+// Get Firebase admin project id by local environment.
+function getProjectId(environment: AdminEnvironment): string {
+  // Map environment to project id.
+  return environment === "dev" ? "hs-levante-admin-dev" : "hs-levante-admin-prod";
+}
+
+// Resolve credential env variable name by environment.
+function getCredentialEnvName(environment: AdminEnvironment): string {
+  // Use environment-specific variable.
+  return environment === "dev"
+    ? ADMIN_DEV_CREDENTIAL_ENV
+    : ADMIN_PROD_CREDENTIAL_ENV;
+}
+
+// Resolve credential JSON path to an absolute file path.
+function resolveCredentialPath(credentialPath: string): string {
+  // Resolve current module directory in ESM context.
+  const currentFilePath = fileURLToPath(import.meta.url);
+  const currentDir = path.dirname(currentFilePath);
+  // Resolve local package root (functions/local).
+  const localRoot = path.resolve(currentDir, "../../");
+  // Resolve repository root (levante-firebase-functions).
+  const repoRoot = path.resolve(currentDir, "../../../../");
+
+  // Return absolute paths unchanged.
+  if (path.isAbsolute(credentialPath)) {
+    return credentialPath;
+  }
+
+  // Try several relative bases and return first existing path.
+  const candidates = [
+    path.resolve(process.cwd(), credentialPath),
+    path.resolve(localRoot, credentialPath),
+    path.resolve(repoRoot, credentialPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Fall back to repo-root relative for consistent behavior.
+  return path.resolve(repoRoot, credentialPath);
+}
+
+// Initialize Firebase admin app and Firestore for local one-off scripts.
+export async function initAdmin(options: InitAdminOptions): Promise<InitializedAdmin> {
+  // Default options for optional parameters.
+  const envFile = options.envFile ?? ".env.local";
+  const appName = options.appName ?? "admin";
+  const shouldInitDefaultApp = options.alsoInitializeDefaultApp ?? false;
+
+  // Load env values from supported env-file locations.
+  const envFileCandidates = getEnvFileCandidates(envFile);
+  for (const candidate of envFileCandidates) {
+    loadEnvFile(candidate);
+  }
+
+  // Read service-account JSON path from env-specific variable first.
+  const credentialEnvName = getCredentialEnvName(options.environment);
+  const credentialFile =
+    process.env[credentialEnvName] || process.env[ADMIN_FALLBACK_CREDENTIAL_ENV];
+  if (!credentialFile) {
+    console.error(
+      `Missing required environment variable for ${options.environment}:
+- ${credentialEnvName}
+Fallback supported for backward compatibility:
+- ${ADMIN_FALLBACK_CREDENTIAL_ENV}
+
+Please set it either by:
+1) exporting it in your shell:
+   export ${credentialEnvName}=path/to/service-account.json
+2) or adding it to an env file (local or repo root), for example:
+   ${credentialEnvName}=/absolute/path/to/service-account.json`,
+    );
+    process.exit(1);
+  }
+
+  // Normalize credential file path before dynamic import.
+  const resolvedCredentialFile = resolveCredentialPath(credentialFile);
+  // Expose credential path for libraries that rely on Application Default Credentials.
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = resolvedCredentialFile;
+
+  // Dynamically import the service-account JSON credentials.
+  const credentials = (
+    await import(resolvedCredentialFile, {
+      assert: { type: "json" },
+    })
+  ).default;
+  const projectId = getProjectId(options.environment);
+
+  // Set explicit project context for Google/Firebase SDKs used by downstream handlers.
+  process.env.GOOGLE_CLOUD_PROJECT = projectId;
+  process.env.GCLOUD_PROJECT = projectId;
+  if (!process.env.FIREBASE_CONFIG) {
+    process.env.FIREBASE_CONFIG = JSON.stringify({ projectId });
+  }
+
+  // Reuse existing named app when already initialized.
+  let app: admin.App;
+  try {
+    app = admin.getApp(appName);
+  } catch (_error) {
+    // Initialize new app when app does not exist yet.
+    app = admin.initializeApp(
+      {
+        credential: admin.cert(credentials),
+        projectId,
+      },
+      appName,
+    );
+  }
+
+  // Optionally ensure the default app is initialized for code paths that call getFirestore() with no app.
+  if (shouldInitDefaultApp) {
+    try {
+      admin.getApp();
+    } catch (_error) {
+      admin.initializeApp({
+        credential: admin.cert(credentials),
+        projectId,
+      });
+    }
+
+    // Initialize default app for the levante-admin package copy of firebase-admin when present.
+    try {
+      const currentFilePath = fileURLToPath(import.meta.url);
+      const currentDir = path.dirname(currentFilePath);
+      const repoRoot = path.resolve(currentDir, "../../../../");
+      const levanteAdminRequire = createRequire(
+        path.resolve(
+          repoRoot,
+          "functions/levante-admin/package.json",
+        ),
+      );
+
+      const adminApp = levanteAdminRequire("firebase-admin/app") as {
+        getApp: () => unknown;
+        initializeApp: (options: unknown) => unknown;
+        cert: (serviceAccountPathOrObject: unknown) => unknown;
+      };
+
+      try {
+        adminApp.getApp();
+      } catch (_levanteAdminDefaultMissingError) {
+        adminApp.initializeApp({
+          credential: adminApp.cert(credentials),
+          projectId,
+        });
+      }
+    } catch (_levanteAdminModuleUnavailableError) {
+      // Ignore if levante-admin package resolution is unavailable in this environment.
+    }
+  }
+
+  // Return both app and Firestore client.
+  return {
+    app,
+    db: getFirestore(app),
+  };
+}


### PR DESCRIPTION
## Proposed changes

There is an ongoing bug on prod which sends an empty list of orgIds to the backend when an assignment is edited (even if assigned schools/classes/groups are visible in the UI). While we have incoming fixes for this, it has caused specific administrations to be assigned to no groups; these need to be reattached. The code here is designed to be run locally but so far has only been tested on dev. It adds

- A small reusable utility, `functions/local/src/utils/init-admin.ts`, to connect to dev/prod using locally stored credentials (currently this instantiated in each local script)
- `identify-detached-admnistrations.ts` which looks in the administrations collection in the specified environment for admininstrations which have empty districts, schools, classes, and groups (i.e., are not assigned to anyone). It writes information about these administrations to a csv file, which includes the site, assignment dates, and target assignedOrgs (derived from the subcollection which was unaffected by the detachment).
- This identifies many detached administrations, allows the user to pick and choose what to re-attach (many are closed or not relevant, e.g., created for DCC testing)
- User to create a small csv with administrationId, districts, schools, classes, groups columns specifiying only the administrations to be restored, and which groups to restore them to - `reattach-administrations.ts` reads this and reattaches the admnistration to the specified groups (multiple groups to be bar separated, e.g., `groupId-1 | groupID-2`)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [x] Other (please describe below)
    - [x] One off operation to re-attach administrations to orgs/users

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
