### PR TITLE
Fix total assigned in progress report

### DIFF
--- a/functions/levante-admin/src/administrations/get-administration-org-progress.ts
+++ b/functions/levante-admin/src/administrations/get-administration-org-progress.ts
@@ -127,15 +127,6 @@ type AssessmentRow = {
   runId?: string;
 };
 
-function missingAnyAssessmentRow(
-  taskDefinitions: { taskId: string }[],
-  assessments: AssessmentRow[]
-): boolean {
-  return taskDefinitions.some(
-    (def) => !assessments.some((a) => a.taskId === def.taskId)
-  );
-}
-
 function classifyTaskForUser(
   assessments: AssessmentRow[],
   taskId: string
@@ -361,8 +352,6 @@ export async function getAdministrationOrgProgressHandler(
       assessments.some((a) => a.startedOn || a.runId)
     ) {
       rollup = "started";
-    } else if (missingAnyAssessmentRow(taskDefinitions, assessments)) {
-      rollup = "notAssigned";
     }
 
     users.push({


### PR DESCRIPTION
## Proposed changes

The progress report was occassionally showing incorrect totals, e.g.:
<img width="756" height="101" alt="Untitled 13" src="https://github.com/user-attachments/assets/8b411f31-5a93-4d48-ac47-0831cb89d000" />


You can see on the left that it's assigned to 40 participants, but only one completion fills the whole bar. This was because some participants were being categorized as not assigned even though they were.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
