### PR TITLE
Adult survey progress not updating correctly

### DIFF
--- a/functions/levante-admin/src/save-survey-results.ts
+++ b/functions/levante-admin/src/save-survey-results.ts
@@ -34,8 +34,9 @@ interface SurveyResponsesInput {
 
 const SURVEY_TASK_IDS = new Set([
   "caregiver-survey",
-  "teacher-survey",
+  "child-survey",
   "survey",
+  "teacher-survey",
 ]);
 
 function isSurveyTaskId(taskId?: string): boolean {
@@ -190,6 +191,14 @@ export async function writeSurveyResponses(
 
         if (surveyAssessmentIndex !== -1) {
           const matchedSurveyTaskId = assessments[surveyAssessmentIndex].taskId;
+          const progressKey = matchedSurveyTaskId.replace(/-/g, "_");
+          const currentProgress = assignmentData?.progress || {};
+          const nextProgressValue =
+            currentProgress[progressKey] === "completed"
+              ? "completed"
+              : isEntireSurveyCompleted
+              ? "completed"
+              : "started";
 
           // Create a copy of the assessments array to modify
           const updatedAssessments = [...assessments];
@@ -200,24 +209,25 @@ export async function writeSurveyResponses(
           let hasAssessmentChanges = false;
           const updates: any = {};
 
-          // Add startedOn timestamp if this is the first survey submission
-          if (isNewDocument && !updatedSurveyAssessment.startedOn) {
+          // Add startedOn timestamp once the survey has any saved response
+          if (!updatedSurveyAssessment.startedOn) {
             updatedSurveyAssessment.startedOn = new Date();
             hasAssessmentChanges = true;
           }
+
+          if (!assignmentData?.started) {
+            updates.started = true;
+          }
+
+          updates.progress = {
+            ...currentProgress,
+            [progressKey]: nextProgressValue,
+          };
 
           // Add completedOn timestamp if entire survey is complete
           if (isEntireSurveyCompleted) {
             updatedSurveyAssessment.completedOn = new Date();
             hasAssessmentChanges = true;
-
-            // Update the progress object properly
-            const currentProgress = assignmentData?.progress || {};
-            const updatedProgress = {
-              ...currentProgress,
-              [matchedSurveyTaskId.replace(/-/g, "_")]: "completed",
-            };
-            updates.progress = updatedProgress;
 
             // Check if assignment should be completed
             if (shouldCompleteAssignment(assignmentDoc, matchedSurveyTaskId)) {

--- a/functions/levante-admin/src/save-survey-results.ts
+++ b/functions/levante-admin/src/save-survey-results.ts
@@ -32,6 +32,16 @@ interface SurveyResponsesInput {
   };
 }
 
+const SURVEY_TASK_IDS = new Set([
+  "caregiver-survey",
+  "teacher-survey",
+  "survey",
+]);
+
+function isSurveyTaskId(taskId?: string): boolean {
+  return !!taskId && SURVEY_TASK_IDS.has(taskId?.trim()?.toLowerCase());
+}
+
 export async function writeSurveyResponses(
   requesterUid: string,
   data: SurveyResponsesInput
@@ -174,12 +184,12 @@ export async function writeSurveyResponses(
         const assessments = assignmentData?.assessments || [];
 
         // Find the survey assessment
-        const surveyAssessmentIndex = assessments.findIndex(
-          (assessment) => assessment.taskId === "survey"
+        const surveyAssessmentIndex = assessments.findIndex((assessment) =>
+          isSurveyTaskId(assessment.taskId)
         );
 
         if (surveyAssessmentIndex !== -1) {
-          const surveyAssessment = assessments[surveyAssessmentIndex];
+          const matchedSurveyTaskId = assessments[surveyAssessmentIndex].taskId;
 
           // Create a copy of the assessments array to modify
           const updatedAssessments = [...assessments];
@@ -207,7 +217,7 @@ export async function writeSurveyResponses(
             updates.progress = updatedProgress;
 
             // Check if assignment should be completed
-            if (shouldCompleteAssignment(assignmentDoc, "survey")) {
+            if (shouldCompleteAssignment(assignmentDoc, matchedSurveyTaskId)) {
               updates.completed = true;
             }
           }

--- a/functions/levante-admin/src/save-survey-results.ts
+++ b/functions/levante-admin/src/save-survey-results.ts
@@ -39,7 +39,7 @@ const SURVEY_TASK_IDS = new Set([
 ]);
 
 function isSurveyTaskId(taskId?: string): boolean {
-  return !!taskId && SURVEY_TASK_IDS.has(taskId?.trim()?.toLowerCase());
+  return !!taskId && SURVEY_TASK_IDS.has(taskId.trim().toLowerCase());
 }
 
 export async function writeSurveyResponses(
@@ -213,7 +213,10 @@ export async function writeSurveyResponses(
 
             // Update the progress object properly
             const currentProgress = assignmentData?.progress || {};
-            const updatedProgress = { ...currentProgress, survey: "completed" };
+            const updatedProgress = {
+              ...currentProgress,
+              [matchedSurveyTaskId.replace(/-/g, "_")]: "completed",
+            };
             updates.progress = updatedProgress;
 
             // Check if assignment should be completed


### PR DESCRIPTION
## Proposed changes

In the BE part of this task, I replaced the hard-coded "survey" string with a usertype-based variable to correctly match the progress of each task.

[FE PR](https://github.com/levante-framework/levante-dashboard/pull/928)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
