### PR TITLE
Restore getSiteOverview indexes

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,6 +15,8 @@
     }
   ],
   "firestore": {
+    "database": "(default)",
+    "location":"nam5",
     "rules": "functions/levante-admin/firestore.rules",
     "indexes": "functions/levante-admin/firestore.indexes.json"
   },

--- a/functions/levante-admin/firestore.indexes.json
+++ b/functions/levante-admin/firestore.indexes.json
@@ -950,6 +950,48 @@
         }
       ],
       "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "groups",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "parentOrgId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "districts.current",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "disabled",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
## Proposed changes

Restores the Firestore indexes for getSiteOverview that were removed [here](https://github.com/levante-framework/levante-firebase-functions/commit/bc72bf276201fb2b7660cff8281406253ba643b3).

## Types of changes

What types of changes does this pull request introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
