### PR TITLE
Functions to backfill corupted survey progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ lib
 .nx/workspace-data
 
 # Firebase Emulator Suite
+emulator_scripts/registered-variants.json
+
 # Emulator data directories
 emulator_data/
 emulator_data_dev/

--- a/functions/local/package.json
+++ b/functions/local/package.json
@@ -38,7 +38,9 @@
     "rebuild-custom-claims": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/rebuild-custom-claims.ts",
     "set-superadmin": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/set-superadmin.ts",
     "identify-detached-administrations": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/identify-detached-administrations.ts",
-    "reattach-administrations": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/reattach-administrations.ts"
+    "reattach-administrations": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/reattach-administrations.ts",
+    "identify-corrupted-survey-progress": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/identify-corrupted-survey-progress.ts",
+    "repair-survey-progress": "NODE_OPTIONS=\"--no-warnings\" npx tsx src/repair-survey-progress.ts"
   },
   "author": "Adam Richie-Halford <richiehalford@gmail.com> (https://richiehalford.org/)",
   "engines": {

--- a/functions/local/src/identify-corrupted-survey-progress.ts
+++ b/functions/local/src/identify-corrupted-survey-progress.ts
@@ -1,0 +1,633 @@
+import * as fs from "fs";
+import * as path from "path";
+import { type DocumentSnapshot, type Firestore } from "firebase-admin/firestore";
+import yargs from "yargs";
+import { initAdmin } from "./utils/init-admin.js";
+import { getOpenAdministrations } from "./utils/get-open-assignments.js";
+
+type SurveyProgressStatus = "assigned" | "started" | "completed";
+
+type SurveyUserType = "student" | "teacher" | "caregiver";
+
+const SURVEY_TASK_BY_USER_TYPE: Record<SurveyUserType, string> = {
+  student: "child-survey",
+  teacher: "teacher-survey",
+  caregiver: "caregiver-survey",
+};
+
+const SURVEY_TASK_IDS = Object.values(SURVEY_TASK_BY_USER_TYPE);
+
+const SURVEY_USER_TYPES = Object.keys(
+  SURVEY_TASK_BY_USER_TYPE
+) as SurveyUserType[];
+
+const CSV_COLUMNS = [
+  "siteId",
+  "siteName",
+  "uid",
+  "administrationId",
+  "taskId",
+  "surveyResponsesStatus",
+  "assessmentStatus",
+  "progressStatus",
+  "isCorrupted",
+] as const;
+
+interface CorruptedSurveyProgressRow {
+  siteId: string;
+  siteName: string;
+  uid: string;
+  administrationId: string;
+  taskId: string;
+  surveyResponsesStatus: SurveyProgressStatus;
+  assessmentStatus: SurveyProgressStatus;
+  progressStatus: SurveyProgressStatus;
+  isCorrupted: boolean;
+}
+
+type SurveyResponseDoc = {
+  completed?: boolean;
+  general?: { isComplete?: boolean };
+  specific?: { isComplete?: boolean }[];
+};
+
+type AssessmentRow = {
+  taskId?: string;
+  startedOn?: unknown;
+  completedOn?: unknown;
+};
+
+function toCsvCell(value: unknown): string {
+  const s = value == null ? "" : String(value);
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+function rowToCsvLine(row: CorruptedSurveyProgressRow): string {
+  return CSV_COLUMNS.map((col) => toCsvCell(row[col])).join(",");
+}
+
+function normalizeSurveyUserType(userType: string): SurveyUserType | null {
+  const normalized = userType.trim().toLowerCase();
+  if (normalized === "student") return "student";
+  if (normalized === "teacher") return "teacher";
+  if (normalized === "caregiver" || normalized === "parent") return "caregiver";
+  return null;
+}
+
+function userTypeMatchesRequested(
+  docUserType: unknown,
+  requested: SurveyUserType
+): boolean {
+  const normalized = normalizeSurveyUserType(
+    typeof docUserType === "string" ? docUserType : ""
+  );
+  return normalized === requested;
+}
+
+function findAssessmentRow(
+  assessments: AssessmentRow[],
+  taskId: string
+): AssessmentRow | undefined {
+  return assessments.find((row) => row.taskId === taskId);
+}
+
+function assessmentStatusFromRow(
+  assessment: AssessmentRow | undefined
+): SurveyProgressStatus {
+  if (!assessment) {
+    return "assigned";
+  }
+  if (assessment.completedOn) {
+    return "completed";
+  }
+  if (assessment.startedOn) {
+    return "started";
+  }
+  return "assigned";
+}
+
+function progressStatusFromAssignment(
+  progress: Record<string, unknown> | undefined,
+  progressKey: string
+): SurveyProgressStatus {
+  const value = progress?.[progressKey];
+  if (value === "assigned" || value === "started" || value === "completed") {
+    return value;
+  }
+  return "assigned";
+}
+
+function allSpecificEntriesComplete(
+  specific: { isComplete?: boolean }[] | undefined
+): boolean {
+  if (!Array.isArray(specific) || specific.length === 0) {
+    return false;
+  }
+  return specific.every((entry) => entry.isComplete === true);
+}
+
+function teacherHasClasses(userData: Record<string, unknown>): boolean {
+  const classes = userData.classes as { current?: string[] } | undefined;
+  return Array.isArray(classes?.current) && classes.current.length > 0;
+}
+
+function caregiverHasLinkedChildren(userData: Record<string, unknown>): boolean {
+  return (
+    Array.isArray(userData.childIds) &&
+    (userData.childIds as string[]).length > 0
+  );
+}
+
+/** Adult surveys use `administrationId`; child-survey runs use `assignmentId` (same value). */
+function surveyResponseMatchesAdministration(
+  data: Record<string, unknown>,
+  administrationId: string,
+  taskId?: string
+): boolean {
+  const matchesAdmin =
+    data.administrationId === administrationId ||
+    data.assignmentId === administrationId;
+  if (!matchesAdmin) {
+    return false;
+  }
+  if (taskId && typeof data.taskId === "string") {
+    return data.taskId === taskId;
+  }
+  return true;
+}
+
+function surveyResponsesStatusForStudent(
+  responseSnap: DocumentSnapshot | null
+): SurveyProgressStatus {
+  if (!responseSnap?.exists) {
+    return "assigned";
+  }
+  const data = responseSnap.data() as SurveyResponseDoc;
+  if (data.completed === true) {
+    return "completed";
+  }
+  return "started";
+}
+
+function surveyResponsesStatusForAdult(
+  responseSnap: DocumentSnapshot | null,
+  userType: SurveyUserType,
+  userData: Record<string, unknown>
+): SurveyProgressStatus {
+  if (!responseSnap?.exists) {
+    return "assigned";
+  }
+
+  const data = responseSnap.data() as SurveyResponseDoc;
+  const generalComplete = data.general?.isComplete === true;
+
+  if (userType === "teacher") {
+    if (!teacherHasClasses(userData)) {
+      return generalComplete ? "completed" : "started";
+    }
+    if (generalComplete && allSpecificEntriesComplete(data.specific)) {
+      return "completed";
+    }
+    return "started";
+  }
+
+  if (!caregiverHasLinkedChildren(userData)) {
+    return generalComplete ? "completed" : "started";
+  }
+  if (generalComplete && allSpecificEntriesComplete(data.specific)) {
+    return "completed";
+  }
+  return "started";
+}
+
+function buildRow(args: {
+  siteId: string;
+  siteName: string;
+  uid: string;
+  administrationId: string;
+  userType: SurveyUserType;
+  taskId: string;
+  userData: Record<string, unknown>;
+  assignmentData: Record<string, unknown>;
+  responseSnap: DocumentSnapshot | null;
+}): CorruptedSurveyProgressRow {
+  const {
+    siteId,
+    siteName,
+    uid,
+    administrationId,
+    userType,
+    taskId,
+    userData,
+    assignmentData,
+    responseSnap,
+  } = args;
+
+  const assessments = Array.isArray(assignmentData.assessments)
+    ? (assignmentData.assessments as AssessmentRow[])
+    : [];
+  const progress = (assignmentData.progress ?? {}) as Record<string, unknown>;
+  const progressKey = taskId.replace(/-/g, "_");
+
+  const assessmentStatus = assessmentStatusFromRow(
+    findAssessmentRow(assessments, taskId)
+  );
+  const progressStatus = progressStatusFromAssignment(progress, progressKey);
+  const surveyResponsesStatus =
+    userType === "student"
+      ? surveyResponsesStatusForStudent(responseSnap)
+      : surveyResponsesStatusForAdult(responseSnap, userType, userData);
+
+  const isCorrupted = !(
+    surveyResponsesStatus === assessmentStatus &&
+    assessmentStatus === progressStatus
+  );
+
+  return {
+    siteId,
+    siteName,
+    uid,
+    administrationId,
+    taskId,
+    surveyResponsesStatus,
+    assessmentStatus,
+    progressStatus,
+    isCorrupted,
+  };
+}
+
+/** Firestore `getAll` is limited to 10 document refs per call. */
+const FIRESTORE_GET_ALL_BATCH_SIZE = 10;
+
+/** Parallel subcollection reads (avoids collection group index). */
+const SURVEY_RESPONSE_READ_CONCURRENCY = 25;
+
+async function loadUserDataByUid(
+  db: Firestore,
+  uids: string[]
+): Promise<Map<string, Record<string, unknown>>> {
+  const uniqueUids = [...new Set(uids)];
+  const byUid = new Map<string, Record<string, unknown>>();
+
+  for (let i = 0; i < uniqueUids.length; i += FIRESTORE_GET_ALL_BATCH_SIZE) {
+    const chunk = uniqueUids.slice(i, i + FIRESTORE_GET_ALL_BATCH_SIZE);
+    const refs = chunk.map((uid) => db.collection("users").doc(uid));
+    const snaps = await db.getAll(...refs);
+    for (const snap of snaps) {
+      if (snap.exists) {
+        byUid.set(snap.id, snap.data() ?? {});
+      }
+    }
+  }
+
+  return byUid;
+}
+
+/**
+ * Loads survey response docs per user subcollection (no collection group index).
+ * Matches `administrationId` (adult surveys) or `assignmentId` (child-survey runs).
+ */
+async function loadSurveyResponsesByUid(
+  db: Firestore,
+  uids: string[],
+  administrationId: string,
+  taskIdByUid?: Map<string, string>
+): Promise<Map<string, DocumentSnapshot>> {
+  const uniqueUids = [...new Set(uids)];
+  const byUid = new Map<string, DocumentSnapshot>();
+
+  for (let i = 0; i < uniqueUids.length; i += SURVEY_RESPONSE_READ_CONCURRENCY) {
+    const chunk = uniqueUids.slice(i, i + SURVEY_RESPONSE_READ_CONCURRENCY);
+    await Promise.all(
+      chunk.map(async (uid) => {
+        const snap = await db
+          .collection("users")
+          .doc(uid)
+          .collection("surveyResponses")
+          .get();
+        const taskId = taskIdByUid?.get(uid);
+        const match = snap.docs.find((doc) =>
+          surveyResponseMatchesAdministration(
+            doc.data(),
+            administrationId,
+            taskId
+          )
+        );
+        if (match) {
+          byUid.set(uid, match);
+        }
+      })
+    );
+  }
+
+  return byUid;
+}
+
+async function getSiteName(
+  db: Firestore,
+  cache: Map<string, string>,
+  siteId: string
+): Promise<string> {
+  if (!siteId) {
+    return "";
+  }
+  if (cache.has(siteId)) {
+    return cache.get(siteId) as string;
+  }
+
+  const siteDoc = await db.collection("districts").doc(siteId).get();
+  if (!siteDoc.exists) {
+    const fallback = `MISSING_SITE(${siteId})`;
+    cache.set(siteId, fallback);
+    return fallback;
+  }
+
+  const siteData = siteDoc.data();
+  const siteName =
+    typeof siteData?.name === "string" && siteData.name.trim().length > 0
+      ? siteData.name.trim()
+      : `UNNAMED_SITE(${siteId})`;
+  cache.set(siteId, siteName);
+  return siteName;
+}
+
+async function scanAdministration(args: {
+  db: Firestore;
+  administrationId: string;
+  siteId: string;
+  siteName: string;
+  surveyUserTypes: SurveyUserType[];
+}): Promise<CorruptedSurveyProgressRow[]> {
+  const { db, administrationId, siteId, siteName, surveyUserTypes } = args;
+
+  const assignmentSnap = await db
+    .collectionGroup("assignments")
+    .where("id", "==", administrationId)
+    .get();
+
+  const uids = assignmentSnap.docs
+    .map((doc) => doc.ref.parent.parent?.id)
+    .filter((uid): uid is string => !!uid);
+
+  const userDataByUid = await loadUserDataByUid(db, uids);
+  const taskIdByUid = new Map<string, string>();
+  for (const uid of uids) {
+    const userData = userDataByUid.get(uid);
+    if (!userData) {
+      continue;
+    }
+    for (const userType of surveyUserTypes) {
+      if (userTypeMatchesRequested(userData.userType, userType)) {
+        taskIdByUid.set(uid, SURVEY_TASK_BY_USER_TYPE[userType]);
+        break;
+      }
+    }
+  }
+  const surveyResponsesByUid = await loadSurveyResponsesByUid(
+    db,
+    uids,
+    administrationId,
+    taskIdByUid
+  );
+  const rows: CorruptedSurveyProgressRow[] = [];
+
+  for (const assignmentDoc of assignmentSnap.docs) {
+    const uid = assignmentDoc.ref.parent.parent?.id;
+    if (!uid) {
+      continue;
+    }
+
+    const userData = userDataByUid.get(uid);
+    if (!userData) {
+      continue;
+    }
+
+    const assignmentData = assignmentDoc.data();
+    const assessments = Array.isArray(assignmentData.assessments)
+      ? (assignmentData.assessments as AssessmentRow[])
+      : [];
+    const responseSnap = surveyResponsesByUid.get(uid) ?? null;
+
+    for (const userType of surveyUserTypes) {
+      if (!userTypeMatchesRequested(userData.userType, userType)) {
+        continue;
+      }
+
+      const taskId = SURVEY_TASK_BY_USER_TYPE[userType];
+      if (!findAssessmentRow(assessments, taskId)) {
+        continue;
+      }
+
+      rows.push(
+        buildRow({
+          siteId,
+          siteName,
+          uid,
+          administrationId,
+          userType,
+          taskId,
+          userData,
+          assignmentData,
+          responseSnap,
+        })
+      );
+    }
+  }
+
+  return rows;
+}
+
+async function scanOpenAdministrations(
+  db: Firestore,
+  siteId?: string
+): Promise<{
+  rows: CorruptedSurveyProgressRow[];
+  administrationCount: number;
+}> {
+  const openAdmins = await getOpenAdministrations({
+    db,
+    siteId,
+    taskIds: SURVEY_TASK_IDS,
+    taskIdsMatch: "any",
+  });
+  console.log(
+    `Open administrations with survey task(s): ${openAdmins.length}`
+  );
+
+  const siteNameCache = new Map<string, string>();
+  const rows: CorruptedSurveyProgressRow[] = [];
+
+  let adminIndex = 0;
+  for (const admin of openAdmins) {
+    adminIndex += 1;
+    const assessments = admin.assessments as AssessmentRow[];
+
+    const surveyUserTypes = SURVEY_USER_TYPES.filter((userType) =>
+      findAssessmentRow(assessments, SURVEY_TASK_BY_USER_TYPE[userType])
+    );
+
+    const adminSiteName = await getSiteName(db, siteNameCache, admin.siteId);
+
+    console.log(
+      `[${adminIndex}/${openAdmins.length}] ${admin.id} — scanning ${surveyUserTypes.join(", ")}...`
+    );
+
+    const adminRows = await scanAdministration({
+      db,
+      administrationId: admin.id,
+      siteId: admin.siteId,
+      siteName: adminSiteName,
+      surveyUserTypes,
+    });
+    rows.push(...adminRows);
+
+    const corruptedInAdmin = adminRows.filter((row) => row.isCorrupted).length;
+    console.log(
+      `  ${adminRows.length} user row(s), ${corruptedInAdmin} corrupted`
+    );
+  }
+
+  return {
+    rows,
+    administrationCount: openAdmins.length,
+  };
+}
+
+function writeCsv(rows: CorruptedSurveyProgressRow[], outputFile: string): string {
+  const outPath = path.resolve(process.cwd(), outputFile);
+  fs.writeFileSync(
+    outPath,
+    [CSV_COLUMNS.join(","), ...rows.map(rowToCsvLine)].join("\n") + "\n",
+    "utf8"
+  );
+  return outPath;
+}
+
+/** surveyResponses should be the source of truth; it must not trail assignment progress. */
+function surveyResponsesBehindOtherStatuses(
+  row: CorruptedSurveyProgressRow
+): boolean {
+  if (row.surveyResponsesStatus === "completed") {
+    return false;
+  }
+  return (
+    row.assessmentStatus === "completed" ||
+    row.progressStatus === "completed"
+  );
+}
+
+function printSurveyResponsesBehindReport(
+  rows: CorruptedSurveyProgressRow[]
+): void {
+  const behind = rows
+    .filter(surveyResponsesBehindOtherStatuses)
+    .sort((a, b) =>
+      a.uid.localeCompare(b.uid) || a.taskId.localeCompare(b.taskId)
+    );
+
+  console.log("\n" + "=".repeat(60));
+  console.log("SURVEY RESPONSES BEHIND ASSIGNMENT (anomaly)");
+  console.log("=".repeat(60));
+  console.log(
+    "surveyResponses is assigned or started, but assessment or progress is completed"
+  );
+  console.log(`Rows: ${behind.length}`);
+  if (behind.length > 0) {
+    console.table(
+      behind.map((row) => ({
+        uid: row.uid,
+        taskId: row.taskId,
+      }))
+    );
+  }
+  console.log("=".repeat(60));
+}
+
+interface CliArgs {
+  environment: "dev" | "prod";
+  envFile: string;
+  siteId?: string;
+  outputFile: string;
+  corruptedOnly: boolean;
+}
+
+const argv = yargs(process.argv.slice(2))
+  .scriptName("identify-corrupted-survey-progress")
+  .usage(
+    "$0 [options]\n\nScans all open administrations with child-survey, teacher-survey," +
+      " or caregiver-survey, compares surveyResponses to assignment progress per user," +
+      " and writes corrupted-survey-progress-by-user.csv."
+  )
+  .options({
+    environment: {
+      alias: ["e", "env"],
+      choices: ["dev", "prod"] as const,
+      default: "dev" as const,
+    },
+    envFile: {
+      alias: ["f", "env-file"],
+      type: "string",
+      default: ".env.local",
+    },
+    siteId: {
+      alias: "s",
+      description: "Only include open administrations for this site (district id)",
+      type: "string",
+    },
+    outputFile: {
+      alias: "o",
+      type: "string",
+      default: "corrupted-survey-progress-by-user.csv",
+    },
+    corruptedOnly: {
+      description: "Only include rows where isCorrupted is true",
+      type: "boolean",
+      default: false,
+    },
+  })
+  .help("help")
+  .alias("help", "h")
+  .strict().argv as CliArgs;
+
+async function main(): Promise<void> {
+  console.log(`identify-corrupted-survey-progress (${argv.environment})`);
+  console.log(`Survey tasks: ${SURVEY_TASK_IDS.join(", ")}`);
+  if (argv.siteId) {
+    console.log(`Site filter: ${argv.siteId}`);
+  }
+
+  const { db } = await initAdmin({
+    environment: argv.environment,
+    envFile: argv.envFile,
+    appName: "identify-corrupted-survey-progress",
+  });
+
+  const { rows, administrationCount } = await scanOpenAdministrations(
+    db,
+    argv.siteId?.trim()
+  );
+
+  const outputRows = argv.corruptedOnly
+    ? rows.filter((row) => row.isCorrupted)
+    : rows;
+
+  const outPath = writeCsv(outputRows, argv.outputFile);
+  const corruptedCount = rows.filter((row) => row.isCorrupted).length;
+
+  console.log("\n" + "=".repeat(60));
+  console.log("IDENTIFY CORRUPTED SURVEY PROGRESS");
+  console.log("=".repeat(60));
+  console.log(`Administrations scanned: ${administrationCount}`);
+  console.log(`Users scanned          : ${rows.length}`);
+  console.log(`Corrupted rows         : ${corruptedCount}`);
+  console.log(`Rows written to CSV    : ${outputRows.length}`);
+  console.log(`Report                 : ${outPath}`);
+  console.log("=".repeat(60));
+
+  printSurveyResponsesBehindReport(rows);
+}
+
+main().catch((err) => {
+  console.error("Fatal script error:", err);
+  process.exit(1);
+});

--- a/functions/local/src/repair-survey-progress.ts
+++ b/functions/local/src/repair-survey-progress.ts
@@ -92,6 +92,27 @@ function isValidStatus(value: string): value is SurveyProgressStatus {
   return value === "assigned" || value === "started" || value === "completed";
 }
 
+const STATUS_RANK: Record<SurveyProgressStatus, number> = {
+  assigned: 0,
+  started: 1,
+  completed: 2,
+};
+
+/**
+ * Returns true when surveyResponses trails the assignment record — i.e. the
+ * assignment already records more progress than surveyResponses does. These
+ * rows represent a distinct anomaly (not the corruption this script repairs)
+ * and must never be repaired with surveyResponsesStatus as the target,
+ * because doing so would overwrite correct assignment data.
+ */
+function isSurveyResponsesBehindAssignment(row: RepairCsvRow): boolean {
+  const surveyRank = STATUS_RANK[row.surveyResponsesStatus];
+  return (
+    STATUS_RANK[row.assessmentStatus] > surveyRank ||
+    STATUS_RANK[row.progressStatus] > surveyRank
+  );
+}
+
 function toDate(value: unknown, label: string): Date {
   if (value instanceof Timestamp) {
     return value.toDate();
@@ -205,6 +226,30 @@ async function repairRow(
     return {
       status: "error",
       message: `invalid surveyResponsesStatus: ${row.surveyResponsesStatus}`,
+    };
+  }
+
+  if (!isValidStatus(row.assessmentStatus)) {
+    return {
+      status: "error",
+      message: `invalid assessmentStatus: ${row.assessmentStatus}`,
+    };
+  }
+
+  if (!isValidStatus(row.progressStatus)) {
+    return {
+      status: "error",
+      message: `invalid progressStatus: ${row.progressStatus}`,
+    };
+  }
+
+  if (isSurveyResponsesBehindAssignment(row)) {
+    return {
+      status: "error",
+      message:
+        `anomalous row: surveyResponsesStatus (${row.surveyResponsesStatus}) trails ` +
+        `assessmentStatus (${row.assessmentStatus}) or progressStatus (${row.progressStatus}). ` +
+        `This row requires separate investigation and must be removed from the input CSV before repair.`,
     };
   }
 

--- a/functions/local/src/repair-survey-progress.ts
+++ b/functions/local/src/repair-survey-progress.ts
@@ -1,0 +1,403 @@
+import * as fs from "fs";
+import * as path from "path";
+import {
+  Timestamp,
+  type DocumentSnapshot,
+  type Firestore,
+} from "firebase-admin/firestore";
+import yargs from "yargs";
+import Papa from "papaparse";
+import { initAdmin } from "./utils/init-admin.js";
+
+type SurveyProgressStatus = "assigned" | "started" | "completed";
+
+const REQUIRED_CSV_COLUMNS = [
+  "siteId",
+  "siteName",
+  "uid",
+  "administrationId",
+  "taskId",
+  "surveyResponsesStatus",
+  "assessmentStatus",
+  "progressStatus",
+  "isCorrupted",
+] as const;
+
+interface RepairCsvRow {
+  siteId: string;
+  siteName: string;
+  uid: string;
+  administrationId: string;
+  taskId: string;
+  surveyResponsesStatus: SurveyProgressStatus;
+  assessmentStatus: SurveyProgressStatus;
+  progressStatus: SurveyProgressStatus;
+  isCorrupted: string;
+}
+
+type AssessmentRow = Record<string, unknown> & {
+  taskId?: string;
+  startedOn?: unknown;
+  completedOn?: unknown;
+};
+
+function parseCsv(inputFile: string): RepairCsvRow[] {
+  const resolvedPath = path.resolve(process.cwd(), inputFile);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Input file not found: ${resolvedPath}`);
+  }
+
+  const content = fs.readFileSync(resolvedPath, "utf8");
+  const parsed = Papa.parse<Record<string, string>>(content, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  if (parsed.errors.length > 0) {
+    throw new Error(
+      `CSV parse error: ${parsed.errors.map((e) => e.message).join("; ")}`
+    );
+  }
+
+  const headers = parsed.meta.fields ?? [];
+  const expected = [...REQUIRED_CSV_COLUMNS];
+  const missing = expected.filter((col) => !headers.includes(col));
+  const extra = headers.filter(
+    (col) => !expected.includes(col as (typeof expected)[number])
+  );
+
+  if (missing.length > 0 || extra.length > 0 || headers.length !== expected.length) {
+    throw new Error(
+      `Invalid CSV columns. Expected exactly: ${expected.join(", ")}. ` +
+        `Got: ${headers.join(", ")}.` +
+        (missing.length ? ` Missing: ${missing.join(", ")}.` : "") +
+        (extra.length ? ` Unexpected: ${extra.join(", ")}.` : "")
+    );
+  }
+
+  return parsed.data.map((raw) => ({
+    siteId: (raw.siteId ?? "").trim(),
+    siteName: (raw.siteName ?? "").trim(),
+    uid: (raw.uid ?? "").trim(),
+    administrationId: (raw.administrationId ?? "").trim(),
+    taskId: (raw.taskId ?? "").trim(),
+    surveyResponsesStatus: (raw.surveyResponsesStatus ?? "").trim() as SurveyProgressStatus,
+    assessmentStatus: (raw.assessmentStatus ?? "").trim() as SurveyProgressStatus,
+    progressStatus: (raw.progressStatus ?? "").trim() as SurveyProgressStatus,
+    isCorrupted: (raw.isCorrupted ?? "").trim(),
+  }));
+}
+
+function isValidStatus(value: string): value is SurveyProgressStatus {
+  return value === "assigned" || value === "started" || value === "completed";
+}
+
+function toDate(value: unknown, label: string): Date {
+  if (value instanceof Timestamp) {
+    return value.toDate();
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === "object" && value && "toDate" in value) {
+    const d = (value as { toDate: () => Date }).toDate();
+    if (d instanceof Date && !Number.isNaN(d.getTime())) {
+      return d;
+    }
+  }
+  throw new Error(`Invalid ${label} on surveyResponses document`);
+}
+
+function taskIdToProgressKey(taskId: string): string {
+  return taskId.replace(/-/g, "_");
+}
+
+function surveyResponseMatchesAdministration(
+  data: Record<string, unknown>,
+  administrationId: string,
+  taskId?: string
+): boolean {
+  const matchesAdmin =
+    data.administrationId === administrationId ||
+    data.assignmentId === administrationId;
+  if (!matchesAdmin) {
+    return false;
+  }
+  if (taskId && typeof data.taskId === "string") {
+    return data.taskId === taskId;
+  }
+  return true;
+}
+
+async function getSurveyResponse(
+  db: Firestore,
+  uid: string,
+  administrationId: string,
+  taskId: string
+): Promise<DocumentSnapshot | null> {
+  const snap = await db
+    .collection("users")
+    .doc(uid)
+    .collection("surveyResponses")
+    .get();
+
+  const match = snap.docs.find((doc) =>
+    surveyResponseMatchesAdministration(
+      doc.data(),
+      administrationId,
+      taskId
+    )
+  );
+  return match ?? null;
+}
+
+function applyAssessmentStatus(
+  assessment: AssessmentRow,
+  targetStatus: SurveyProgressStatus,
+  surveySnap: DocumentSnapshot | null
+): AssessmentRow {
+  const next: AssessmentRow = { ...assessment };
+
+// don't think this ever occurs; target status is only ever assigned or completed; but just in case.
+  if (targetStatus === "assigned") {
+    delete next.startedOn;
+    delete next.completedOn;
+    return next;
+  }
+
+  if (!surveySnap?.exists) {
+    throw new Error(
+      "surveyResponses document required when surveyResponsesStatus is started or completed"
+    );
+  }
+
+  const surveyData = surveySnap.data() ?? {};
+  const startedAt = surveyData.createdAt ?? surveyData.timeStarted;
+  if (!startedAt) {
+    throw new Error("surveyResponses createdAt/timeStarted is missing");
+  }
+
+  next.startedOn = toDate(startedAt, "createdAt/timeStarted");
+
+  if (targetStatus === "completed") {
+    const completedAt =
+      surveyData.updatedAt ??
+      surveyData.timeFinished ??
+      startedAt;
+    next.completedOn = toDate(completedAt, "updatedAt/timeFinished");
+  } else {
+    delete next.completedOn;
+  }
+
+  return next;
+}
+
+async function repairRow(
+  db: Firestore,
+  row: RepairCsvRow,
+  dryRun: boolean
+): Promise<{ status: "repaired" | "skipped" | "error"; message: string }> {
+  if (!row.uid || !row.administrationId || !row.taskId) {
+    return { status: "error", message: "missing uid, administrationId, or taskId" };
+  }
+
+  if (!isValidStatus(row.surveyResponsesStatus)) {
+    return {
+      status: "error",
+      message: `invalid surveyResponsesStatus: ${row.surveyResponsesStatus}`,
+    };
+  }
+
+  const assignmentRef = db
+    .collection("users")
+    .doc(row.uid)
+    .collection("assignments")
+    .doc(row.administrationId);
+
+  const assignmentSnap = await assignmentRef.get();
+  if (!assignmentSnap.exists) {
+    return { status: "error", message: "assignment document not found" };
+  }
+
+  const assignmentData = assignmentSnap.data() ?? {};
+  const assessments = Array.isArray(assignmentData.assessments)
+    ? ([...assignmentData.assessments] as AssessmentRow[])
+    : [];
+  const assessmentIdx = assessments.findIndex((a) => a.taskId === row.taskId);
+  if (assessmentIdx < 0) {
+    return {
+      status: "error",
+      message: `assignment has no assessment row for taskId ${row.taskId}`,
+    };
+  }
+
+  const targetStatus = row.surveyResponsesStatus;
+  const needsAssessment = row.assessmentStatus !== targetStatus;
+  const needsProgress = row.progressStatus !== targetStatus;
+
+  if (!needsAssessment && !needsProgress) {
+    return {
+      status: "skipped",
+      message: "assessmentStatus and progressStatus already match surveyResponsesStatus",
+    };
+  }
+
+  const updates: Record<string, unknown> = {};
+  const changedParts: string[] = [];
+
+  if (needsAssessment) {
+    const surveySnap = await getSurveyResponse(
+      db,
+      row.uid,
+      row.administrationId,
+      row.taskId
+    );
+    assessments[assessmentIdx] = applyAssessmentStatus(
+      assessments[assessmentIdx],
+      targetStatus,
+      surveySnap
+    );
+    updates.assessments = assessments;
+    changedParts.push("assessment");
+  }
+
+  if (needsProgress) {
+    const progressKey = taskIdToProgressKey(row.taskId);
+    updates.progress = {
+      ...((assignmentData.progress ?? {}) as Record<string, unknown>),
+      [progressKey]: targetStatus,
+    };
+    changedParts.push(`progress.${progressKey}`);
+  }
+
+  if (dryRun) {
+    return {
+      status: "repaired",
+      message: `dry-run: would update ${changedParts.join(", ")} to ${targetStatus}`,
+    };
+  }
+
+  await assignmentRef.update(updates);
+
+  return {
+    status: "repaired",
+    message: `updated ${changedParts.join(", ")} to ${targetStatus}`,
+  };
+}
+
+interface CliArgs {
+  environment: "dev" | "prod";
+  envFile: string;
+  inputFile: string;
+  dryRun: boolean;
+  testSize?: number;
+}
+
+const argv = yargs(process.argv.slice(2))
+  .scriptName("repair-survey-progress")
+  .usage(
+    "$0 [options]\n\nReads corrupted-survey-progress CSV from identify-corrupted-survey-progress," +
+      " and aligns assignment assessments + progress to surveyResponsesStatus."
+  )
+  .options({
+    environment: {
+      alias: ["e", "env"],
+      choices: ["dev", "prod"] as const,
+      default: "dev" as const,
+    },
+    envFile: {
+      alias: ["f", "env-file"],
+      type: "string",
+      default: ".env.local",
+    },
+    inputFile: {
+      alias: "i",
+      description: "CSV from identify-corrupted-survey-progress",
+      type: "string",
+      demandOption: true,
+    },
+    dryRun: {
+      alias: "d",
+      description: "Log changes without writing to Firestore",
+      type: "boolean",
+      default: true,
+    },
+    testSize: {
+      alias: "t",
+      description: "Max corrupted rows to process",
+      type: "number",
+    },
+  })
+  .help("help")
+  .alias("help", "h")
+  .strict().argv as CliArgs;
+
+async function main(): Promise<void> {
+  console.log(`repair-survey-progress (${argv.environment})`);
+  console.log(`Input: ${argv.inputFile}`);
+  console.log(`Dry run: ${argv.dryRun}`);
+
+  const allRows = parseCsv(argv.inputFile);
+  let corruptedRows = allRows.filter(
+    (row) => row.isCorrupted.toLowerCase() === "true"
+  );
+
+  if (argv.testSize) {
+    corruptedRows = corruptedRows.slice(0, argv.testSize);
+  }
+
+  console.log(`CSV rows: ${allRows.length}, corrupted to repair: ${corruptedRows.length}`);
+
+  if (corruptedRows.length === 0) {
+    console.log("No corrupted rows to repair.");
+    return;
+  }
+
+  const { db } = await initAdmin({
+    environment: argv.environment,
+    envFile: argv.envFile,
+    appName: "repair-survey-progress",
+  });
+
+  let repaired = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (let i = 0; i < corruptedRows.length; i += 1) {
+    const row = corruptedRows[i];
+    const result = await repairRow(db, row, argv.dryRun);
+
+    if (result.status === "repaired") {
+      repaired += 1;
+    } else if (result.status === "skipped") {
+      skipped += 1;
+    } else {
+      errors += 1;
+      console.error(
+        `[${i + 1}/${corruptedRows.length}] ${row.uid} ${row.administrationId} ${row.taskId}: ${result.message}`
+      );
+    }
+
+    if ((i + 1) % 50 === 0 || i === corruptedRows.length - 1) {
+      console.log(`[${i + 1}/${corruptedRows.length}] processed...`);
+    }
+  }
+
+  console.log("\n" + "=".repeat(60));
+  console.log("REPAIR SUMMARY");
+  console.log("=".repeat(60));
+  console.log(`Corrupted rows processed : ${corruptedRows.length}`);
+  console.log(`Repaired                 : ${repaired}`);
+  console.log(`Skipped (already ok)   : ${skipped}`);
+  console.log(`Errors                   : ${errors}`);
+  if (argv.dryRun) {
+    console.log("Dry run enabled — no Firestore writes were made.");
+    console.log("Re-run with --dryRun=false to apply changes.");
+  }
+  console.log("=".repeat(60));
+}
+
+main().catch((err) => {
+  console.error("Fatal script error:", err);
+  process.exit(1);
+});

--- a/functions/local/src/repair-survey-progress.ts
+++ b/functions/local/src/repair-survey-progress.ts
@@ -133,6 +133,19 @@ function taskIdToProgressKey(taskId: string): string {
   return taskId.replace(/-/g, "_");
 }
 
+/**
+ * An assignment is complete when it has at least one assessment and every
+ * non-optional assessment has a completedOn timestamp. Used to roll the
+ * top-level `completed` flag up after repairing assessment timestamps, so the
+ * assignment-level flag stays consistent with assessments[].completedOn.
+ */
+function allAssessmentsCompleted(assessments: AssessmentRow[]): boolean {
+  if (assessments.length === 0) return false;
+  return assessments.every(
+    (a) => Boolean(a.completedOn) || a.optional === true
+  );
+}
+
 function surveyResponseMatchesAdministration(
   data: Record<string, unknown>,
   administrationId: string,
@@ -313,6 +326,27 @@ async function repairRow(
       [progressKey]: targetStatus,
     };
     changedParts.push(`progress.${progressKey}`);
+  }
+
+  // Roll the top-level `completed` flag up so it stays consistent with the
+  // repaired assessment timestamps. Only set it to true (never downgrade), so a
+  // partial repair can't flip a legitimately completed assignment to false.
+  if (
+    assignmentData.completed !== true &&
+    allAssessmentsCompleted(assessments)
+  ) {
+    updates.completed = true;
+    if (assignmentData.started !== true) {
+      updates.started = true;
+    }
+    changedParts.push("completed");
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return {
+      status: "skipped",
+      message: "no changes needed after repair evaluation",
+    };
   }
 
   if (dryRun) {

--- a/functions/local/src/utils/get-open-assignments.ts
+++ b/functions/local/src/utils/get-open-assignments.ts
@@ -1,0 +1,133 @@
+import { Timestamp, type Firestore } from "firebase-admin/firestore";
+import { initAdmin } from "./init-admin.js";
+
+export type GetOpenAdministrationsEnvironment = "dev" | "prod";
+
+export interface OpenAdministrationSummary {
+  id: string;
+  siteId: string;
+  assessments: { taskId?: unknown }[];
+}
+
+export interface GetOpenAdministrationsOptions {
+  /**
+   * When set, filter by taskId on `assessments`.
+   * Default `all` = administration must include every listed taskId.
+   * Use `any` when the administration only needs one of the tasks (e.g. survey tasks).
+   */
+  taskIds?: string[];
+  taskIdsMatch?: "all" | "any";
+  /** District/site document id (`administrations.siteId`). */
+  siteId?: string;
+  /** Firebase project environment. Defaults to `dev`. */
+  environment?: GetOpenAdministrationsEnvironment;
+  /** Env file passed through to `initAdmin` (default `.env.local`). */
+  envFile?: string;
+  /** Reuse an existing Firestore client instead of calling `initAdmin`. */
+  db?: Firestore;
+}
+
+function isAdministrationOpen(
+  dateOpened: Timestamp | undefined,
+  dateClosed: Timestamp | undefined,
+  now: Timestamp
+): boolean {
+  if (dateClosed && dateClosed.toMillis() < now.toMillis()) {
+    return false;
+  }
+  if (dateOpened && dateOpened.toMillis() > now.toMillis()) {
+    return false;
+  }
+  return true;
+}
+
+function administrationMatchesTaskIds(
+  assessments: { taskId?: unknown }[],
+  taskIds: string[],
+  match: "all" | "any"
+): boolean {
+  const adminTaskIds = new Set(
+    assessments
+      .map((a) => (typeof a.taskId === "string" ? a.taskId.trim() : ""))
+      .filter((id) => id.length > 0)
+  );
+  return match === "any"
+    ? taskIds.some((taskId) => adminTaskIds.has(taskId))
+    : taskIds.every((taskId) => adminTaskIds.has(taskId));
+}
+
+/**
+ * Returns open administrations at call time, optionally filtered by site and taskIds.
+ * An administration is open when `dateOpened` has passed and `dateClosed` is in the future.
+ */
+export async function getOpenAdministrations(
+  options: GetOpenAdministrationsOptions = {}
+): Promise<OpenAdministrationSummary[]> {
+  const environment = options.environment ?? "dev";
+  const db =
+    options.db ??
+    (
+      await initAdmin({
+        environment,
+        envFile: options.envFile,
+        appName: "get-open-administrations",
+      })
+    ).db;
+
+  const taskIds = options.taskIds
+    ?.map((id) => id.trim())
+    .filter((id) => id.length > 0);
+  const taskIdsMatch = options.taskIdsMatch ?? "all";
+  const siteId = options.siteId?.trim();
+
+  const now = Timestamp.now();
+  const querySnap = await db
+    .collection("administrations")
+    .where("dateClosed", ">", now)
+    .get();
+
+  const administrations: OpenAdministrationSummary[] = [];
+
+  for (const doc of querySnap.docs) {
+    const data = doc.data();
+    const dateOpened = data.dateOpened as Timestamp | undefined;
+    const dateClosed = data.dateClosed as Timestamp | undefined;
+
+    if (!isAdministrationOpen(dateOpened, dateClosed, now)) {
+      continue;
+    }
+
+    const adminSiteId =
+      typeof data.siteId === "string" ? data.siteId.trim() : "";
+
+    if (siteId && adminSiteId !== siteId) {
+      continue;
+    }
+
+    const assessments = Array.isArray(data.assessments)
+      ? (data.assessments as { taskId?: unknown }[])
+      : [];
+
+    if (taskIds && taskIds.length > 0) {
+      if (!administrationMatchesTaskIds(assessments, taskIds, taskIdsMatch)) {
+        continue;
+      }
+    }
+
+    administrations.push({
+      id: doc.id,
+      siteId: adminSiteId,
+      assessments,
+    });
+  }
+
+  return administrations;
+}
+
+/** Returns ids only; see `getOpenAdministrations` for full metadata. */
+export async function getOpenAdministrationIds(
+  options: GetOpenAdministrationsOptions = {}
+): Promise<string[]> {
+  const administrations = await getOpenAdministrations(options);
+  return administrations.map((admin) => admin.id);
+}


### PR DESCRIPTION
## Proposed changes
This includes three new files:
- functons/local/src/utils/get-open-assignments.ts. A utility to find open assignments, which can take tasks and siteId as arguments (optionally).
- local/src/identify-corrupted-survey-progress.ts - this finds the corrupted users and dumps their information into a csv for inspection
- local/src/repair-survey-progress.ts - this repairs the corrupted users' progress, matching survey progress across surveyResponses, `assignments/{id}/assessments[].startedOn` and `completedOn` and, `assignments/{id}/progress.{task_id}`

The identification step has found a handfull of users where `surveyResponses` is behind `assessments`; this will require a separate investigation. The indentify step flags these and they should be removed from the csv before repair.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
