### PR TITLE
Adult survey progress not updating correctly

### DIFF
--- a/functions/levante-admin/src/save-survey-results.ts
+++ b/functions/levante-admin/src/save-survey-results.ts
@@ -32,6 +32,10 @@ interface SurveyResponsesInput {
   };
 }
 
+function isSurveyTask(taskId?: string): boolean {
+  return !!taskId && taskId.toLowerCase().includes("survey");
+}
+
 export async function writeSurveyResponses(
   requesterUid: string,
   data: SurveyResponsesInput
@@ -174,8 +178,8 @@ export async function writeSurveyResponses(
         const assessments = assignmentData?.assessments || [];
 
         // Find the survey assessment
-        const surveyAssessmentIndex = assessments.findIndex(
-          (assessment) => assessment.taskId === "survey"
+        const surveyAssessmentIndex = assessments.findIndex((assessment) =>
+          isSurveyTask(assessment.taskId)
         );
 
         if (surveyAssessmentIndex !== -1) {

--- a/functions/levante-admin/src/save-survey-results.ts
+++ b/functions/levante-admin/src/save-survey-results.ts
@@ -183,7 +183,15 @@ export async function writeSurveyResponses(
         );
 
         if (surveyAssessmentIndex !== -1) {
-          const surveyAssessment = assessments[surveyAssessmentIndex];
+          const matchedSurveyTaskId = assessments[surveyAssessmentIndex].taskId;
+          const progressKey = matchedSurveyTaskId.replace(/-/g, "_");
+          const currentProgress = assignmentData?.progress || {};
+          const nextProgressValue =
+            currentProgress[progressKey] === "completed"
+              ? "completed"
+              : isEntireSurveyCompleted
+              ? "completed"
+              : "started";
 
           // Create a copy of the assessments array to modify
           const updatedAssessments = [...assessments];
@@ -194,24 +202,28 @@ export async function writeSurveyResponses(
           let hasAssessmentChanges = false;
           const updates: any = {};
 
-          // Add startedOn timestamp if this is the first survey submission
-          if (isNewDocument && !updatedSurveyAssessment.startedOn) {
+          // Add startedOn timestamp once the survey has any saved response
+          if (!updatedSurveyAssessment.startedOn) {
             updatedSurveyAssessment.startedOn = new Date();
             hasAssessmentChanges = true;
           }
+
+          if (!assignmentData?.started) {
+            updates.started = true;
+          }
+
+          updates.progress = {
+            ...currentProgress,
+            [progressKey]: nextProgressValue,
+          };
 
           // Add completedOn timestamp if entire survey is complete
           if (isEntireSurveyCompleted) {
             updatedSurveyAssessment.completedOn = new Date();
             hasAssessmentChanges = true;
 
-            // Update the progress object properly
-            const currentProgress = assignmentData?.progress || {};
-            const updatedProgress = { ...currentProgress, survey: "completed" };
-            updates.progress = updatedProgress;
-
             // Check if assignment should be completed
-            if (shouldCompleteAssignment(assignmentDoc, "survey")) {
+            if (shouldCompleteAssignment(assignmentDoc, matchedSurveyTaskId)) {
               updates.completed = true;
             }
           }

--- a/functions/levante-admin/src/tasks/completeTask.ts
+++ b/functions/levante-admin/src/tasks/completeTask.ts
@@ -90,6 +90,7 @@ export const completeTask = onCall(async (request) => {
 
       // NOW DO ALL WRITES
       const docRef = getAssignmentDocRef(db, userId, administrationId);
+      const progressKey = taskId.replace(/-/g, "_");
 
       // Update this assessment's `completedOn` timestamp
       updateAssignedTaskInTransaction(
@@ -100,10 +101,17 @@ export const completeTask = onCall(async (request) => {
         transaction
       );
 
+      const assignmentUpdates: { [key: string]: unknown } = {
+        [`progress.${progressKey}`]: "completed",
+        started: true,
+      };
+
       // Mark assignment as complete if all assessments are now completed
       if (shouldComplete) {
-        transaction.update(docRef, { completed: true });
+        assignmentUpdates.completed = true;
       }
+
+      transaction.update(docRef, assignmentUpdates);
     });
 
     logger.info(userId, "completed task", {


### PR DESCRIPTION
## Proposed changes

I replaced the hard-coded string "survey" with a function to better check if it's a survey task. The function checks the same way it does on the frontend.

**TEACHER SURVEY**

https://github.com/user-attachments/assets/6a1c23a0-2f67-41a9-8275-1e6d99170c8d


**PARENT/CAREGIVER SURVEY**

https://github.com/user-attachments/assets/6d2b4147-9190-45ed-a919-58eb9e0f8184


**CHILD/STUDENT SURVEY**

https://github.com/user-attachments/assets/20665cc3-5fc4-40a8-b945-ab99ae9d3174

**Note: this PR replaces [PR#69](https://github.com/levante-framework/levante-firebase-functions/pull/69), which was closed because it was built upon a misunderstanding.**

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
