### PR TITLE
Fix: add missing levante-zod dep

### DIFF
--- a/functions/levante-admin/package.json
+++ b/functions/levante-admin/package.json
@@ -28,6 +28,7 @@
     "@bdelab/roar-utils": "^1.1.0",
     "@firebase/logger": "^0.4.4",
     "@google-cloud/secret-manager": "^4.2.2",
+    "@levante-framework/levante-zod": "^1.1.1",
     "@levante-framework/permissions-core": "^1.2.1",
     "axios": "^1.4.0",
     "axios-oauth-1.0a": "^0.3.6",


### PR DESCRIPTION
## Proposed changes

- Add missing @levante-framework/levante-zod dep to `functions/levante-admin/package.json` so deployment succeeds

## Types of changes

What types of changes does this pull request introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

The Cloud Run container is built using `functions/levante-admin/package.json`. Adding a dependency to the root `package.json` alone works for local dev because of npm workspace hoisting, but if it needs to be in the deployed image it must be added to `functions/levante-admin/package.json`.