### PR TITLE
Remove all references to assessmentUid

### DIFF
--- a/__tests__/rules/admin-user-management.rules.test.ts
+++ b/__tests__/rules/admin-user-management.rules.test.ts
@@ -188,7 +188,6 @@ describe("Admin User Management", () => {
             districts: { current: ["d1"] },
             schools: { current: ["s1"] },
             classes: { current: ["c1"] },
-            assessmentUid: "uid123",
           }),
       );
     });
@@ -267,33 +266,6 @@ describe("Admin User Management", () => {
       await assertFails(
         admin.firestore().doc("users/student1").update({
           archived: true,
-        }),
-      );
-    });
-
-    test("admin cannot update assessmentUid field", async () => {
-      await setupTestData(testEnv, async (ctx) => {
-        await ctx
-          .firestore()
-          .doc("users/student1")
-          .set({
-            userType: "student",
-            name: "Student 1",
-            districts: { current: ["d1"] },
-            assessmentUid: "original-uid",
-          });
-        await ctx
-          .firestore()
-          .doc("userClaims/admin1")
-          .set({
-            claims: { adminOrgs: { districts: ["d1"] } },
-          });
-      });
-
-      const admin = createUserWithClaims(testEnv, "admin1");
-      await assertFails(
-        admin.firestore().doc("users/student1").update({
-          assessmentUid: "new-uid",
         }),
       );
     });

--- a/emulator_scripts/seeders/users.js
+++ b/emulator_scripts/seeders/users.js
@@ -102,7 +102,6 @@ async function createUsers(adminApp) {
         // Create user document according to schema
         const userData = {
           archived: false,
-          assessmentUid: uid,
           createdAt: admin.firestore.FieldValue.serverTimestamp(),
           displayName: userDef.displayName,
           email: userDef.email,

--- a/functions/levante-admin/firestore-schema.ts
+++ b/functions/levante-admin/firestore-schema.ts
@@ -168,7 +168,6 @@ export interface School {
 export interface Claims {
   adminOrgs: OrgRefMap;
   adminUid?: string; // Purpose needs clarification
-  assessmentUid?: string;
   minimalAdminOrgs: OrgRefMap;
   roarUid?: string; // Purpose needs clarification
   super_admin: boolean;
@@ -210,7 +209,6 @@ export interface User {
     started: string[]; // Document IDs from `administrations` collection that are started
   };
   archived: boolean;
-  assessmentUid: string;
   classes: OrgAssociationMap;
   createdAt: Timestamp;
   disabled: boolean;
@@ -244,7 +242,6 @@ export interface AssignmentAssessment {
     testData: boolean;
     userData: {
       assessmentPid: string | null;
-      assessmentUid: string | null;
       email: string;
       name: string | null;
       username: string;
@@ -371,12 +368,11 @@ export interface VariantDoc {
 /**
  * Interface for documents in the `guests` collection.
  * Manages temporary or guest user data, often used for one-off assessments without full user registration.
- * Document ID: Guest assessmentUid.
+ * Document ID: guest UID.
  */
 export interface GuestDoc {
   age?: number;
   assessmentPid?: string;
-  assessmentUid?: string;
   created?: Timestamp;
   lastUpdated?: Timestamp;
   tasks?: string[]; // Task IDs interacted with
@@ -422,7 +418,6 @@ export interface RunDoc {
   timeFinished?: Timestamp;
   timeStarted?: Timestamp;
   userData?: {
-    assessmentUid?: string; // Guest UID
     variantId?: string;
   };
 }

--- a/functions/levante-admin/firestore.indexes.json
+++ b/functions/levante-admin/firestore.indexes.json
@@ -907,25 +907,6 @@
           "arrayConfig": "CONTAINS"
         },
         {
-          "fieldPath": "assessmentUid",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "DESCENDING"
-        }
-      ],
-      "density": "SPARSE_ALL"
-    },
-    {
-      "collectionGroup": "users",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "groups.all",
-          "arrayConfig": "CONTAINS"
-        },
-        {
           "fieldPath": "lastUpdated",
           "order": "ASCENDING"
         },

--- a/functions/levante-admin/src/interfaces.ts
+++ b/functions/levante-admin/src/interfaces.ts
@@ -294,8 +294,6 @@ export interface IUids {
   roarUid: string;
   /* The auth UID of the user in the admin Firebase project. */
   adminUid: string;
-  /* The auth UID of the user in the assessment Firebase project. */
-  assessmentUid: string;
 }
 
 /**

--- a/functions/local/src/make-super-admin.ts
+++ b/functions/local/src/make-super-admin.ts
@@ -10,7 +10,7 @@ if (!adminCredentialFile) {
     - ROAR_ADMIN_FIREBASE_CREDENTIALS
     - ROAR_ASSESSMENT_FIREBASE_CREDENTIALS
     Please set these environment variables using
-    export ROAR_ADMIN_FIREBASE_CREDENTIALS=path/to/credentials/for/admin/project.json`
+    export ROAR_ADMIN_FIREBASE_CREDENTIALS=path/to/credentials/for/admin/project.json`,
   );
   process.exit(1);
 }
@@ -42,7 +42,7 @@ const adminFirestore = getFirestore(adminApp);
 // Get the target user's current custom claims.
 await adminAuth.getUserByEmail(email).then((targetRecord) => {
   const targetUid = targetRecord.uid;
-  
+
   return toggleSuperAdmin({
     targetUid: targetUid,
     db: adminFirestore,
@@ -68,7 +68,6 @@ export interface ICustomClaims {
   super_admin?: boolean;
   roarUid: string;
   adminUid: string;
-  assessmentUid: string;
   adminOrgs?: IAdminClaims;
 }
 

--- a/functions/local/src/toggle-super-admin.ts
+++ b/functions/local/src/toggle-super-admin.ts
@@ -9,7 +9,7 @@ if (!adminCredentialFile) {
     `Missing required environment variables:
     - LEVANTE_ADMIN_FIREBASE_CREDENTIALS
     Please set these environment variables using
-    export LEVANTE_ADMIN_FIREBASE_CREDENTIALS=path/to/credentials/for/admin/project.json`
+    export LEVANTE_ADMIN_FIREBASE_CREDENTIALS=path/to/credentials/for/admin/project.json`,
   );
   process.exit(1);
 }
@@ -68,7 +68,6 @@ export interface ICustomClaims {
   super_admin?: boolean;
   roarUid: string;
   adminUid: string;
-  assessmentUid: string;
   adminOrgs?: IAdminClaims;
 }
 


### PR DESCRIPTION
## Proposed changes

**Low-risk cleanup**

- Removed low-risk assessmentUid schema/type references from functions/levante-admin/firestore-schema.ts, functions/levante-admin/src/interfaces.ts, and local super-admin claim interfaces.
- Removed the assessmentUid rules-test fixture/assertion from __tests__/rules/admin-user-management.rules.test.ts.
- Removed the emulator user seeder field from emulator_scripts/seeders/users.js.
- Removed the stale Firestore index on assessmentUid from functions/levante-admin/firestore.indexes.json.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
