### PR TITLE
Add schema for responses and source of truth for site and school information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ node_modules/
 # Yarn Integrity file
 .yarn-integrity
 
+# CSV data files (survey/source spreadsheets, script inputs/outputs)
+*.csv
+**/*.csv
+
 # dotenv environment variables file
 .env
 .env.*

--- a/emulator_scripts/seed-data/org-information-forms/schoolInformation.seed.json
+++ b/emulator_scripts/seed-data/org-information-forms/schoolInformation.seed.json
@@ -1,0 +1,349 @@
+{
+  "collection": "formDefinitions",
+  "documentId": "schoolInformation",
+  "definition": {
+    "currentVersionId": "v1",
+    "formDescription": "School information survey for researchers describing schools within a LEVANTE site.",
+    "fieldsDescription": {
+      "numStudents": "Number of students in the school.",
+      "studentAgeYoungest": "Typical age of the youngest students in the school.",
+      "studentAgeOldest": "Typical age of the oldest students in the school.",
+      "numTeachers": "Number of teachers in the school.",
+      "studentsPerTeacher": "Number of students per teacher in the school.",
+      "avgClassSize": "Average class size at the school",
+      "schoolFunding": "Funding source for the school.",
+      "schoolReligious": "Whether the school has a religious affiliation.",
+      "schoolTuition": "Whether families have to pay tuition for their child to attend the school.",
+      "schoolSelectiveness": "Admission or selection process for the school.",
+      "schoolSelectivenessOther": "Optional - free text for describing non-standard admission or selection processes.",
+      "instructionLanguages": "List of languages spoken at the school.",
+      "schoolDayLength": "Aprroximate length of the school day in hours",
+      "teacherQuals": "Minimum teaching qualifications."
+    }
+  },
+  "versions": {
+    "v1": {
+      "registered": true,
+      "versionNumber": 1,
+      "createdAt": "2026-06-16T00:00:00.000Z",
+      "updatedAt": "2026-06-16T00:00:00.000Z",
+      "liveFrom": "2026-06-16T00:00:00.000Z",
+      "liveUntil": null,
+      "generalPrompt":"<p>Before creating your school, we need to know some basic information to help us understand the data we collect. Any responses here will not be released with the general data until they have been deemed non-identifying according to LEVANTE policies.</p><p>There are 12 questions in this form and it should take about 5-10 minutes to complete, but you can save your progress and come back later if needed.</p>",
+      "sectionInfo":[
+        {"sectionId":"studentStats","title":"Students","description":"Provide some information about who attends this school."},
+        {"sectionId":"teacherStats","title":"Teachers","description":"Provide some information abotu teachers at the school."},
+        {"sectionId":"schoolFunding","title":"Funding, Admissions & Affiliations","description":"Provide some information about how the school is funded, how students are selected, and whether it is religiously affiliated."},
+        {"sectionId":"instructionStats","title":"Instruction","description":"These questions are about the instruction at this school."},
+        {"sectionId":"schoolExperience","title":"School Experience","description":"Finally, provide some information about languages spoken at the shchool and the length of the school day."}
+      ],
+      "fullFields": [
+        {
+          "itemId": "school_01",
+          "variableName": "numStudents",
+          "kind": "single-select",
+          "required": true,
+          "sectionId": "studentStats",
+          "questionText": "Across all grades, how many students attend this school?",
+          "options": [
+            {
+              "value": "less_than_20",
+              "label": "Fewer than 20 students"
+            },
+            {
+              "value": "20_to_49",
+              "label": "20-49 students"
+            },
+            {
+              "value": "50_to_149",
+              "label": "50-149 students"
+            },
+            {
+              "value": "150_to_499",
+              "label": "150-499 students"
+            },
+            {
+              "value": "500_to_999",
+              "label": "500-999 students"
+            },
+            {
+              "value": "1000_to_1999",
+              "label": "1,000–1,999 students"
+            },
+            {
+              "value": "2000_or_more",
+              "label": "2,000 or more students"
+            }
+          ]
+        },
+        {
+          "itemId": "school_02_youngest",
+          "variableName": "studentAgeYoungest",
+          "kind": "number",
+          "required": true,
+          "sectionId": "studentStats",
+          "questionText": "What is the typical age of the youngest students at this school?"
+        },
+        {
+          "itemId": "school_02_oldest",
+          "variableName": "studentAgeOldest",
+          "kind": "number",
+          "required": true,
+          "sectionId": "studentStats",
+          "questionText": "What is the typical age of the oldest students at this school?"
+        },
+        {
+          "itemId": "school_03",
+          "variableName": "numTeachers",
+          "kind": "single-select",
+          "required": true,
+          "sectionId": "teacherStats",
+          "questionText": "How many teachers work at this school?",
+          "options": [
+            {
+              "value": "less_than_5",
+              "label": "Fewer than 5 teachers"
+            },
+            {
+              "value": "5_to_9",
+              "label": "5-9 teachers"
+            },
+            {
+              "value": "10_to_24",
+              "label": "10-24 teachers"
+            },
+            {
+              "value": "25_to_49",
+              "label": "25-49 teachers"
+            },
+            {
+              "value": "50_to_99",
+              "label": "50-99 teachers"
+            },
+            {
+              "value": "100_to_149",
+              "label": "100-149 teachers"
+            },
+            {
+              "value": "150_or_more",
+              "label": "150 or more teachers"
+            }
+          ]
+        },
+        {
+          "itemId": "school_04",
+          "variableName": "studentsPerTeacher",
+          "kind": "number",
+          "required": true,
+          "sectionId": "teacherStats",
+          "questionText": "What is the teacher to student ratio at this school? Provide the number of students per teacher.",
+          "infoExample": "For example, if there are roughly 30 students for every teacher, enter '30'."
+        },
+        {
+          "itemId": "school_05",
+          "variableName": "avgClassSize",
+          "kind": "single-select",
+          "required": true,
+          "sectionId": "teacherStats",
+          "questionText": "What is the average number of students per class at this school?",
+          "options": [
+            {
+              "value": "less_than_10",
+              "label": "Fewer than 10 students"
+            },
+            {
+              "value": "10_to_19",
+              "label": "10 to 19 students"
+            },
+            {
+              "value": "20_to_29",
+              "label": "20 to 29 students"
+            },
+            {
+              "value": "30_to_39",
+              "label": "30 to 39 students"
+            },
+            {
+              "value": "40_to_49",
+              "label": "40 to 49 students"
+            },
+            {
+              "value": "50_to_99",
+              "label": "50 to 99 students"
+            },
+            {
+              "value": "100_or_more",
+              "label": "100 or more students"
+            }
+          ]
+        },
+        {
+          "itemId": "school_12",
+          "variableName": "teacherQuals",
+          "kind": "single-select",
+          "required": true,
+          "sectionId": "teacherStats",
+          "questionText": "What minimum qualifications are required for teachers at this school?",
+          "options": [
+            {
+              "value": "less_than_undergrad",
+              "label": "Less than an undergraduate degree"
+            },
+            {
+              "value": "undergrad_any",
+              "label": "An undergraduate degree of any kind"
+            },
+            {
+              "value": "undergrad_ed",
+              "label": "An undergraduate degree in education or with an education credential"
+            },
+            {
+              "value": "postgrad_any",
+              "label": "A postgraduate degree of any kind"
+            },
+            {
+              "value": "postgrad_ed",
+              "label": "A postgraduate degree in education or with an education credential"
+            }
+          ]
+        },
+        {
+          "itemId": "school_06",
+          "variableName": "schoolFunding",
+          "kind": "single-select",
+          "required": true,
+          "sectionId": "schoolFunding",
+          "questionText": "How is this school funded?",
+          "options": [
+            {
+              "value": "government",
+              "label": "Government funded"
+            },
+            {
+              "value": "private",
+              "label": "Privately funded"
+            },
+            {
+              "value": "other",
+              "label": "Other"
+            }
+          ]
+        },
+        {
+          "itemId": "school_07",
+          "variableName": "schoolReligious",
+          "kind": "single-select",
+          "required": true,
+          "sectionId": "schoolFunding",
+          "questionText": "Does this school have a religious affiliation?",
+          "options": [
+            {
+              "value": "yes",
+              "label": "Yes"
+            },
+            {
+              "value": "no",
+              "label": "No"
+            }
+          ]
+        },
+        {
+          "itemId": "school_08",
+          "variableName": "schoolTuition",
+          "kind": "single-select",
+          "required": true,
+          "sectionId": "schoolFunding",
+          "questionText": "Do families have to pay tuition for their child to attend this school?",
+          "options": [
+            {
+              "value": "yes",
+              "label": "Yes"
+            },
+            {
+              "value": "no",
+              "label": "No"
+            }
+          ]
+        },
+        {
+          "itemId": "school_09",
+          "variableName": "schoolSelectiveness",
+          "kind": "multi-select",
+          "required": true,
+          "sectionId": "schoolFunding",
+          "questionText": "What is the process for students to be admitted to this school? Select all that apply.",
+          "options": [
+            {
+              "value": "selective",
+              "label": "By application, where selection is based on students' achievement or background"
+            },
+            {
+              "value": "lottery_based",
+              "label": "By application, where selection is lottery-based"
+            },
+            {
+              "value": "residence_based",
+              "label": "Based on residence; the schools serves children who reside in a specific area"
+            },
+            {
+              "value": "other",
+              "label": "Other"
+            }
+          ]
+        },
+        {
+          "itemId": "school_09a",
+          "variableName": "schoolSelectivenessOther",
+          "kind": "text",
+          "required": true,
+          "sectionId": "schoolFunding",
+          "questionText": "If you selected \"Other,\" please explain",
+          "displayLogic": {
+            "field": "schoolSelectiveness",
+            "includes": "other"
+          }
+        },
+        {
+          "itemId": "school_10",
+          "variableName": "instructionLanguages",
+          "kind": "text",
+          "required": true,
+          "sectionId": "schoolExperience",
+          "questionText": "What languages do children regularly hear during instruction at this school?"
+        },
+        {
+          "itemId": "school_11",
+          "variableName": "schoolDayLength",
+          "kind": "number",
+          "required": true,
+          "sectionId": "schoolExperience",
+          "questionText": "How long is the school day? Please respond in the approximate number of hours between when children typically arrive for school, and when they leave."
+        }
+      ]
+    }
+  },
+  "_meta": {
+    "sourceCsv": "School Survey - Sheet1.csv",
+    "generatedAt": "2026-06-16T12:32:23.052Z",
+    "skippedRows": [
+      {
+        "itemId": "NA",
+        "variableName": "site",
+        "reason": "If not collected via dashboard"
+      },
+      {
+        "itemId": "NA",
+        "variableName": "schoolPseudonym",
+        "reason": "If not collected via dashboard"
+      }
+    ],
+    "schemaGaps": [],
+    "mappingNotes": [],
+    "dashboardProvidedResponseFields": [
+      "siteId",
+      "siteName",
+      "schoolId",
+      "schoolPseudonym"
+    ]
+  }
+}

--- a/emulator_scripts/seed-data/org-information-forms/siteInformation.seed.json
+++ b/emulator_scripts/seed-data/org-information-forms/siteInformation.seed.json
@@ -1,0 +1,347 @@
+{
+  "collection": "formDefinitions",
+  "documentId": "siteInformation",
+  "definition": {
+    "currentVersionId": "v1",
+    "formDescription": "Site information survey for researchers characterizing a LEVANTE data collection site.",
+    "fieldsDescription": {
+      "sampleApproach": "Description of site sampling approach.",
+      "sampleApproachOther": "If you selected \"Other,\" please explain.",
+      "siteRecruitment": "Description of site recruitment approach.",
+      "adminApproach": "Information regarding where data collection/task administration took place.",
+      "adminApproachOther": "Where data collection/task administration took place, other than school, home, or laboratory.",
+      "testConditions": "Description of the testing conditions that participants experienced at this site.",
+      "equipmentType": "Kind of equipment used for data collection/task administration.",
+      "equipmentDevices": "Specific devices used for data collection/task administration.",
+      "siteGeoArea": "General geographic area of the site.",
+      "siteGeoType": "Description of the geographic area's urbanicity.",
+      "sitePopulationSize": "Approximate population size.",
+      "siteRaceEthnicity": "General description of the population's racial/ethnic composition.",
+      "siteSES": "General description of the population's socioeconomic status.",
+      "siteLifestyle": "General description of the population's living styles, including household style and composition.",
+      "siteTech": "General description of the exposure and prevalence of technology among children and caregivers, especially smartphones and other touchscreen devices",
+      "siteLanguages": "Commonly spoken languages in the targeted geographic area.",
+      "siteSubsistence": "Subsistence styles of the population.",
+      "schoolingAgeStart": "Age at which formal school attendance typically starts.",
+      "schoolingAgeEnd": "Age at which formal school attendance typically ends.",
+      "schoolingProgression": "Description of the typical progression of schooling at the site.",
+      "schoolingTeacherQuals": "Description of teacher qualifications",
+      "anythingElse": "Additional information regarding site's sampling, recruitment, population, or administration?"
+    }
+  },
+  "versions": {
+    "v1": {
+      "registered": true,
+      "versionNumber": 1,
+      "createdAt": "2026-06-16T00:00:00.000Z",
+      "updatedAt": "2026-06-16T00:00:00.000Z",
+      "liveFrom": "2026-06-16T00:00:00.000Z",
+      "liveUntil": null,
+      "generalPrompt":"<p>This form collects information, including open-ended text responses, to characterize site(s) in detail. The form contains 22 questions and should take about 10-15 minutes to complete, but you can save your progress and come back later if needed.</p><p>Where it meets the conditions of non-identifiability in our policies, text you provide may be used to describe this site or it's characteristics in our data releases and scientific publications. However, note that this text will not be released with the general data until it has been anonymized according to LEVANTE policies.</p><p>For open text repsonses, please describe the site accurately in full sentences. For examples, click the '?' icon next to a question.</p>",
+      "sectionInfo":[
+        {"sectionId":"sampleRecruit","title":"Sampling & Recruitment","description":"Provide some information about the sampling and recruitment methods in your site."},
+        {"sectionId":"testingInfo","title":"Testing Locations & Devices","description":"Describe testing conditions and equipment used for data collection"},
+        {"sectionId":"locationInfo","title":"Site Area","description":"Your responses to the following questions will help the research community understand the population(s) studied at this site."},
+        {"sectionId":"demographicInfo","title":"Demographic Information","description":"This section asks for some information about the population(s) studied at this site."},
+        {"sectionId":"lifestyleInfo","title":"Lifestyle Information","description":"This section asks for some information about the lifestyle of the population(s) studied at this site."},
+        {"sectionId":"languageEducationInfo","title":"Language & Education","description":"This section asks for some information about schooling and language use in population(s) studied at this site. Your responses to the following questions will help the research community understand the education system at this site."},
+        {"sectionId":"anythingElse","title":"Anything Else?","description":"Is there anything else you would like us to know about your site's sampling, recruitment, population, or administration?"}
+      ],
+      "fullFields": [
+        {
+          "itemId": "site_02",
+          "variableName": "sampleApproach",
+          "kind": "multi-select",
+          "required": true,
+          "questionText": "What was this site's sampling approach?",
+          "sectionId": "sampleRecruit",
+          "options": [
+            {
+              "value": "representative",
+              "label": "Representative"
+            },
+            {
+              "value": "convenience",
+              "label": "Convenience"
+            },
+            {
+              "value": "school-based",
+              "label": "School-Based"
+            },
+            {
+              "value": "other",
+              "label": "Other"
+            }
+          ]
+        },
+        {
+          "itemId": "site_02a",
+          "variableName": "sampleApproachOther",
+          "kind": "text",
+          "required": true,
+          "sectionId": "sampleRecruit",
+          "questionText": "If you selected \"Other,\" please explain.",
+          "displayLogic": {
+            "field": "sampleApproach",
+            "includes": "other"
+          }
+        },
+        {
+          "itemId": "site_03",
+          "variableName": "siteRecruitment",
+          "kind": "text",
+          "required": true,
+          "sectionId": "sampleRecruit",
+          "questionText": "How were participants recruited?",
+          "infoExample": "For example, <ul><li>Data were collected using family-based remote assessment. Families were recruited through an existing database of residents who were first contacted by telephone to invite participation.</li><li>Our team conducted school-based data collection at four schools, selected for convenience from schools that had participated in previous projects with the university.</li></ul>"
+        },
+        {
+          "itemId": "site_04",
+          "variableName": "adminApproach",
+          "kind": "multi-select",
+          "required": true,
+          "sectionId": "sampleRecruit",
+          "questionText": "Did this site collect data at schools, at home, or in the lab? Select all that apply.",
+          "options": [
+            {
+              "value": "school",
+              "label": "School"
+            },
+            {
+              "value": "home",
+              "label": "Home"
+            },
+            {
+              "value": "lab",
+              "label": "Lab"
+            },
+            {
+              "value": "other",
+              "label": "Other"
+            }
+          ]
+        },
+        {
+          "itemId": "site_04a",
+          "variableName": "adminApproachOther",
+          "kind": "text",
+          "required": true, 
+          "sectionId": "sampleRecruit",
+          "questionText": "If you selected \"Other,\" please explain.",
+          "displayLogic": {
+            "field": "adminApproach",
+            "includes": "other"
+          }
+        },
+        {
+          "itemId": "site_05",
+          "variableName": "testConditions",
+          "kind": "text",
+          "required": true,
+          "sectionId": "testingInfo",
+          "questionText": "Describe the testing conditions that participants experienced at this site.",
+          "infoExample": "For example, <ul><li>The research team oversaw data collection using a group testing format on tablets provided by the team, with larger groups for older children and smaller groups for younger children.</li><li>Families who agreed to partake received login instructions to complete the assigned LEVANTE tasks at home using their own computer or tablet.</li></ul>"
+        },
+        {
+          "itemId": "site_06",
+          "variableName": "equipmentType",
+          "kind": "multi-select",
+          "required": true,
+          "sectionId": "testingInfo",
+          "questionText": "What types of equipment were used to administer tasks at this site?",
+          "options": [
+            {
+              "value": "tablet",
+              "label": "Tablet"
+            },
+            {
+              "value": "computer",
+              "label": "Computer (laptop or desktop)"
+            }
+          ]
+        },
+        {
+          "itemId": "site_07",
+          "variableName": "equipmentDevices",
+          "kind": "text",
+          "required": true,
+          "sectionId": "testingInfo",
+          "questionText": "What device(s) were used for data collection? If possible, please state the make and model."
+        },
+        {
+          "itemId": "site_08",
+          "variableName": "siteGeoArea",
+          "kind": "text",
+          "required": true,
+          "sectionId":"locationInfo",
+          "questionText": "For this site, what geographic area(s) were participants recruited from?"
+        },
+        {
+          "itemId": "site_09",
+          "variableName": "siteGeoType",
+          "kind": "text",
+          "required": true,
+          "sectionId":"locationInfo",
+          "questionText": "Describe this area in terms of its urbanicity. Is the area urban or rural? If it is a city, is it considered to be small, mid-sized, or large? (e.g., \"Participants were drawn from Leipzig, a medium-sized urban center.\""
+        },
+        {
+          "itemId": "site_10",
+          "variableName": "sitePopulationSize",
+          "kind": "text",
+          "required": true,
+          "sectionId":"locationInfo",
+          "questionText": "What is the approximate population size of the geographic area that participants were recruited from?"
+        },
+        {
+          "itemId": "site_11",
+          "variableName": "siteRaceEthnicity",
+          "kind": "text",
+          "required": true,
+          "sectionId":"demographicInfo",
+          "questionText": "Provide a general description of the population's racial/ethnic composition.",
+          "infoExample": "For example, \"Leipzig is culturally diverse, with around 17% of the population having a migration background (primarily from Syria, Ukraine, and the Russian Federation).\""
+        },
+        {
+          "itemId": "site_12",
+          "variableName": "siteSES",
+          "kind": "text",
+          "required": true,
+          "sectionId":"demographicInfo",
+          "questionText": "Provide a general description of the population's socioeconomic status. Include information about resident's education status, income, or other indicators of socioeconomic status when available.",
+          "infoExample": "For example, \"According to recent census estimates, London residents have a mean education level of some postsecondary education, and the median household income is approximately $80,000 CAD.\""
+        },
+        {
+          "itemId": "site_13",
+          "variableName": "siteLifestyle",
+          "kind": "text",
+          "required": true,
+          "sectionId":"demographicInfo",
+          "questionText": "Provide a general description of the population's living styles, including household style and composition. (e.g., \"The majority of households live in apartments, and multi-generational housing is common.\")"
+        },
+        {
+          "itemId": "site_16",
+          "variableName": "siteSubsistence",
+          "kind": "multi-select",
+          "required": true,
+          "sectionId":"lifestyleInfo",
+          "questionText": "What are the main subsistence style(s) (means of satisfying food and survival needs) of this population?",
+          "options": [
+            {
+              "value": "foraging",
+              "label": "Foraging"
+            },
+            {
+              "value": "horticultural",
+              "label": "Horticultural"
+            },
+            {
+              "value": "pastoral",
+              "label": "Pastoral"
+            },
+            {
+              "value": "agricultural",
+              "label": "Agricultural"
+            },
+            {
+              "value": "industrial",
+              "label": "Industrial food production"
+            }
+          ]
+        },
+        {
+          "itemId": "site_14",
+          "variableName": "siteTech",
+          "kind": "text",
+          "required": true,
+          "sectionId":"lifestyleInfo",
+          "questionText": "Provide a general description of the exposure and prevalence of technology among children and caregivers, especially smartphones and other touchscreen devices.",
+          "infoExample": "For example, \"Technology prevalence, including touchscreens and mobile phones, is high. Most caregivers have a personal device and/or tablet, as do about a third of the children in our study's age range.\""
+        },
+        {
+          "itemId": "site_15",
+          "variableName": "siteLanguages",
+          "kind": "text",
+          "required": true,
+          "sectionId":"languageEducationInfo",
+          "questionText": "What are most commonly spoken languages in this population? Please include any languages spoken by >5% of the population in your targeted geographic area."
+        },
+
+        {
+          "itemId": "site_17",
+          "variableName": "schoolingAgeStart",
+          "kind": "number",
+          "required": true,
+          "sectionId":"languageEducationInfo",
+          "questionText": "At this site, at what age does formal school attendance typically start?"
+        },
+        {
+          "itemId": "site_18",
+          "variableName": "schoolingAgeEnd",
+          "kind": "number",
+          "required": true,
+          "sectionId":"languageEducationInfo",
+          "questionText": "At this site, at what age does formal school attendance typically end?"
+        },
+        {
+          "itemId": "site_19",
+          "variableName": "schoolingProgression",
+          "kind": "text",
+          "required": true,
+          "sectionId":"languageEducationInfo",
+          "questionText": "Please describe a typical progression of schoooling at this site. At what ages do students move between schools (for example, from primary to middle or secondary school)? How many years do they spend at each stage?",
+          "infoExample": "For example, \"Children typically attend elementary school from kindergarten through grade 5 or 6, beginning at age 5 and lasting about 6–7 years. Students then move to middle school or junior high school for grades 6–8 or 7–8, usually from ages 11–13, lasting 2–3 years, before progressing to high school, which lasts 4 years.\""
+        },
+        {
+          "itemId": "site_20",
+          "variableName": "schoolingTeacherQuals",
+          "kind": "single-select",
+          "required": true,
+          "sectionId":"languageEducationInfo",
+          "questionText": "What minimum qualifications are typically required for teachers at your site?",
+          "options": [
+            {
+              "value": "less_than_undergrad",
+              "label": "Less than an undergraduate degree"
+            },
+            {
+              "value": "undergrad_any",
+              "label": "Undergraduate degree of any kind"
+            },
+            {
+              "value": "undergrad_ed",
+              "label": "Undergraduate degree in education or with an education credential"
+            },
+            {
+              "value": "postgrad_any",
+              "label": "Postgraduate degree of any kind"
+            },
+            {
+              "value": "postgrad_ed",
+              "label": "Postgraduate degree in education or with an education credential"
+            }
+          ]
+        },
+        {
+          "itemId": "site_21",
+          "variableName": "anythingElse",
+          "kind": "text",
+          "required": true,
+          "sectionId":"anythingElse",
+          "questionText": "Is there anything else you would like us to know about your site's sampling, recruitment, population, or administration?"
+        }
+      ]
+    }
+  },
+  "_meta": {
+    "sourceCsv": "Site Survey - Sheet1.csv",
+    "generatedAt": "2026-06-16T12:32:23.039Z",
+    "skippedRows": [],
+    "schemaGaps": [],
+    "mappingNotes": [
+      "site_06: CSV response_options uses \"table\"; seed uses \"tablet\" to match the Tablet label"
+    ],
+    "dashboardProvidedResponseFields": [
+      "siteId"
+    ]
+  }
+}

--- a/functions/levante-admin/firestore-schema.ts
+++ b/functions/levante-admin/firestore-schema.ts
@@ -1,9 +1,9 @@
 import * as admin from "firebase-admin";
 
-/** Firestore Timestamp type alias. */
+// Type alias for Firestore Timestamp
 export type Timestamp = admin.firestore.Timestamp;
 
-/** Generic structure for organization references used in multiple places. */
+// Generic structure for organization references used in multiple places
 export interface OrgRefMap {
   classes: string[];
   districts: string[];
@@ -12,39 +12,30 @@ export interface OrgRefMap {
   schools: string[];
 }
 
-/** Assessment condition rule within an administration. */
+// Structure for Assessment Condition Rules within Administrations
 export interface AssessmentConditionRule {
-  /** e.g. `"userType"`. */
-  field: string;
-  /** e.g. `"EQUAL"`, `"AND"`. */
-  op: string;
-  /** e.g. `"student"`. */
-  value: string | number | boolean | null;
+  field: string; // e.g., "userType"
+  op: string; // e.g., "EQUAL", "AND"
+  value: string | number | boolean | null; // e.g., "student"
 }
 
-/** Assessment conditions within an administration. */
+// Structure for Assessment Conditions within Administrations
 export interface AssessmentConditions {
-  /** Structure needs clarification based on usage. */
-  assigned: Record<string, unknown>;
+  assigned: Record<string, unknown>; // Structure needs clarification based on usage
   conditions: AssessmentConditionRule[];
 }
 
-/** Individual assessment within an administration. */
+// Structure for individual Assessments within Administrations
 export interface Assessment {
   conditions: AssessmentConditions;
-  /** Parameters specific to the task. */
-  params: Record<string, unknown>;
-  /** e.g. `"egma-math"`. */
-  taskName: string;
-  /** e.g. `"egma-math"`. */
-  taskId: string;
-  /** Reference to a task variant. */
-  variantId: string;
-  /** e.g. `"es-CO"`. */
-  variantName: string;
+  params: Record<string, unknown>; // Parameters specific to the task
+  taskName: string; // e.g., "egma-math"
+  taskId: string; // e.g., "egma-math"
+  variantId: string; // Reference to a task variant
+  variantName: string; // e.g., "es-CO"
 }
 
-/** Legal information within administrations and assignedOrgs. */
+// Structure for Legal information within Administrations and AssignedOrgs
 export interface LegalInfo {
   amount: string;
   assent: string | null;
@@ -52,36 +43,25 @@ export interface LegalInfo {
   expectedTime: string;
 }
 
-/**
- * Document in the `administrations` collection.
- * Stores metadata about each administration (assignment) including the sequence of
- * tasks, involved organizations, and visibility control.
- */
+// Interface for documents in the `administrations` collection
+// Stores metadata about each administration (assignment) including the sequence of tasks, involved organizations, and visibility control.
 export interface Administration {
   assessments: Assessment[];
-  /** Document IDs from the `classes` collection. */
-  classes: string[];
-  /** User UID. */
-  createdBy: string;
+  classes: string[]; // Document IDs from `classes` collection
+  createdBy: string; // User UID
   creatorName: string;
   dateClosed: Timestamp;
   dateCreated: Timestamp;
   dateOpened: Timestamp;
-  /** Document IDs from the `districts` collection. */
-  districts: string[];
-  /** Document IDs from the `families` collection. */
-  families: string[];
-  /** Document IDs from the `groups` collection. */
-  groups: string[];
+  districts: string[]; // Document IDs from `districts` collection
+  families: string[]; // Document IDs from `families` collection
+  groups: string[]; // Document IDs from `groups` collection
   legal: LegalInfo;
   minimalOrgs: OrgRefMap;
-  /** Internal name. */
-  name: string;
-  /** Public-facing name. */
-  publicName: string;
+  name: string; // Internal name
+  publicName: string; // Public-facing name
   readOrgs: OrgRefMap;
-  /** Document IDs from the `schools` collection. */
-  schools: string[];
+  schools: string[]; // Document IDs from `schools` collection
   sequential: boolean;
   siteId: string;
   syncChunksCompleted?: number;
@@ -92,92 +72,63 @@ export interface Administration {
   testData: boolean;
 }
 
-/** Document in the `assignedOrgs` subcollection of `administrations`. */
+// Interface for documents in the `assignedOrgs` subcollection of `administrations`
 export interface AssignedOrg {
   administrationId: string;
-  /** User UID of the administration creator. */
-  createdBy: string;
-  /** Copied from administration. */
-  dateClosed: Timestamp;
-  /** Timestamp of assignment creation or copied from admin; needs clarification. */
-  dateCreated: Timestamp;
-  /** Copied from administration. */
-  dateOpened: Timestamp;
-  /** Copied from administration. */
-  legal: LegalInfo;
-  /** Copied from administration. */
-  name: string;
-  /** Document ID of the assigned organization. */
-  orgId: string;
-  /** Type of the assigned organization. */
-  orgType: "classes" | "districts" | "families" | "groups" | "schools";
-  /** Copied from administration. */
-  publicName: string;
-  /** Copied from administration. */
-  testData: boolean;
-  /** Timestamp of assignment creation/update. */
-  timestamp: Timestamp;
+  createdBy: string; // User UID of the administration creator
+  dateClosed: Timestamp; // Copied from administration
+  dateCreated: Timestamp; // Timestamp of assignment creation or copied from admin? Needs clarification
+  dateOpened: Timestamp; // Copied from administration
+  legal: LegalInfo; // Copied from administration
+  name: string; // Copied from administration
+  orgId: string; // Document ID of the assigned organization
+  orgType: "classes" | "districts" | "families" | "groups" | "schools"; // Type of the assigned organization
+  publicName: string; // Copied from administration
+  testData: boolean; // Copied from administration
+  timestamp: Timestamp; // Timestamp of assignment creation/update
 }
 
-/** Document in the `readOrgs` subcollection of `administrations`. */
+// Interface for documents in the `readOrgs` subcollection of `administrations`
 export interface ReadOrg {
   administrationId: string;
-  /** User UID of the administration creator. */
-  createdBy: string;
-  /** Copied from administration. */
-  dateClosed: Timestamp;
-  /** Timestamp of assignment creation or copied from admin; needs clarification. */
-  dateCreated: Timestamp;
-  /** Copied from administration. */
-  dateOpened: Timestamp;
-  /** Copied from administration. */
-  legal: LegalInfo;
-  /** Copied from administration. */
-  name: string;
-  /** Document ID of the assigned organization. */
-  orgId: string;
-  /** Type of the assigned organization. */
-  orgType: "classes" | "districts" | "families" | "groups" | "schools";
-  /** Copied from administration. */
-  publicName: string;
-  /** Copied from administration. */
-  testData: boolean;
-  /** Timestamp of assignment creation/update. */
-  timestamp: Timestamp;
+  createdBy: string; // User UID of the administration creator
+  dateClosed: Timestamp; // Copied from administration
+  dateCreated: Timestamp; // Timestamp of assignment creation or copied from admin? Needs clarification
+  dateOpened: Timestamp; // Copied from administration
+  legal: LegalInfo; // Copied from administration
+  name: string; // Copied from administration
+  orgId: string; // Document ID of the assigned organization
+  orgType: "classes" | "districts" | "families" | "groups" | "schools"; // Type of the assigned organization
+  publicName: string; // Copied from administration
+  testData: boolean; // Copied from administration
+  timestamp: Timestamp; // Timestamp of assignment creation/update
 }
 
-/** Document in the `stats` subcollection of `administrations`. */
+// Interface for the stats subcollection of `administrations`
 export interface Stat {
   assignment: Record<string, number>;
   survey: Record<string, number>;
 }
 
-/**
- * Document in the `classes` collection.
- * Details about classes, including school affiliation and optional educational details.
- */
+// Interface for documents in the `classes` collection
+// Details about classes, including school affiliation and optional educational details
 export interface Class {
   archived: boolean;
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  /** User UID. */
-  createdBy: string;
+  createdBy: string; // User UID
   districtId: string;
-  /** Same as document ID. */
-  id: string;
+  id: string; // Same as document ID
   name: string;
   schoolId: string;
 }
 
-/**
- * Document in the `districts` collection.
- * Manages information about districts (sites), including associated schools.
- */
+// Interface for documents in the `districts` collection
+// Manages information about districts (sites), including associated schools.
 export interface District {
   archived: boolean;
   createdAt: Timestamp;
-  /** User UID. */
-  createdBy: string;
+  createdBy: string; // User UID
   updatedAt: Timestamp;
   name: string;
   tags: string[];
@@ -185,46 +136,34 @@ export interface District {
   schools?: string[];
 }
 
-/**
- * Document in the `groups` collection.
- * Manages group (cohort) data, potentially representing subgroups within a district (site).
- * Catch-all type for when a group of users does not fit into a traditional org type.
- */
+// Interface for documents in the `groups` collection
+// Purpose: Manages group (cohort) data, potentially representing subgroups within a district (site).
+// This is a catch all type group for when a group of users does not fit into the traditional group type.
 export interface Group {
   archived: boolean;
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  /** User UID. */
-  createdBy: string;
-  /** Document ID of the parent organization. */
-  parentOrgId: string;
-  /** Type of the parent organization. */
-  parentOrgType: "district";
+  createdBy: string; // User UID
+  parentOrgId: string; // Document ID of the parent organization
+  parentOrgType: "district"; // Type of the parent organization
   name: string;
   tags: string[];
 }
 
-/**
- * Document in the `schools` collection.
- * Contains data about schools, including their districts.
- */
+// Interface for documents in the `schools` collection
+// Contains data about schools, including their districts.
 export interface School {
   archived: boolean;
-  /** Document IDs of classes. */
-  classes?: string[];
+  classes?: string[]; // Document IDs of classes
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  /** User UID. */
-  createdBy: string;
+  createdBy: string; // User UID
   districtId: string;
-  /** Same as document ID. */
-  id: string;
+  id: string; // Same as document ID
   name: string;
 }
 
-/**
- * Org information forms: the `formDefinitions` collection and response subcollections.
- */
+// --- Org information forms (`formDefinitions` collection and response subcollections) ---
 
 /**
  * Document in the `siteInformation` subcollection of `districts`.
@@ -369,67 +308,51 @@ export interface FormDefinitionVersion {
   fullFields: FullInformationFormField[];
 }
 
-/**
- * Claims structure within `UserClaims`.
- * Manages custom claims for users, facilitating access control based on administrative
- * roles or organizational (group) affiliations.
- */
+// Structure for Claims within UserClaims
+// Manages custom claims for users, facilitating access control based on administrative roles or organizational (Group) affiliations.
 export interface Claims {
   adminOrgs: OrgRefMap;
-  /** Purpose needs clarification. */
-  adminUid?: string;
+  adminUid?: string; // Purpose needs clarification
   assessmentUid?: string;
   minimalAdminOrgs: OrgRefMap;
-  /** Purpose needs clarification. */
-  roarUid?: string;
+  roarUid?: string; // Purpose needs clarification
   super_admin: boolean;
 }
 
-/** Document in the `userClaims` collection. Document ID is the user UID. */
+// Interface for documents in the `userClaims` collection (Document ID is User UID)
 export interface UserClaims {
   claims: Claims;
-  /** Unix milliseconds timestamp. */
-  lastUpdated: number;
+  lastUpdated: number; // Unix milliseconds timestamp?
   testData?: boolean;
 }
 
-/** Admin-specific data within `users` documents. */
+// Structure for Admin-specific data within Users
 export interface AdminData {
-  /** IDs of administrations. */
-  administrationsCreated: string[];
+  administrationsCreated: string[]; // IDs of administrations
 }
 
-/** Organizational associations within `users` documents. */
+// Structure for organizational associations within Users
 export interface OrgAssociationMap {
   all: string[];
   current: string[];
-  /** Structure needs clarification. */
-  dates: Record<string, Timestamp>;
+  dates: Record<string, Timestamp>; // Structure needs clarification
 }
 
-/** User legal document acceptance within `users` documents. */
+// Structure for user legal document acceptance within Users
 export interface UserLegal {
-  /** Keyed by form hash/identifier. */
-  assent: Record<string, Timestamp>;
-  /** Keyed by ToS version hash/identifier. */
-  tos: Record<string, Timestamp>;
+  assent: Record<string, Timestamp>; // Keyed by form hash/identifier
+  tos: Record<string, Timestamp>; // Keyed by ToS version hash/identifier
 }
 
-/**
- * Document in the `users` collection. Document ID is the user UID.
- * Stores comprehensive user data including assignments and organizational affiliations.
- */
+// Interface for documents in the `users` collection (Document ID is User UID)
+// Stores comprehensive user data including assignments and organizational affiliations.
 export interface User {
-  /** Only for admin users. */
-  adminData?: AdminData;
-  /** Only for participants. */
+  adminData?: AdminData; // only for admin users
   assignments?: {
-    /** Document IDs from `administrations` that are assigned. */
-    assigned: string[];
-    /** Document IDs from `administrations` that are completed. */
-    completed: string[];
-    /** Document IDs from `administrations` that are started. */
-    started: string[];
+    // only for participants
+    assigned: string[]; // Document IDs from `administrations` collection that are assigned
+    completed: string[]; // Document IDs from `administrations` collection that are completed
+    started: string[]; // Document IDs from `administrations` collection that are started
   };
   archived: boolean;
   assessmentUid: string;
@@ -442,17 +365,14 @@ export interface User {
   groups: OrgAssociationMap;
   legal: UserLegal;
   schools: OrgAssociationMap;
-  /** e.g. `"google"`; only for admin users. */
-  sso?: string;
+  sso?: string; // e.g., "google" only for admin users
   userType: "admin" | "teacher" | "student" | "parent";
   testData?: boolean;
   roles: { siteId: string; role: string; siteName: string }[];
 }
 
-/**
- * Document in the `assignments` subcollection of `users`.
- * Represents a specific administration assigned to a user.
- */
+// Interface for the assignments subcollection of `users`
+// Represents a specific administration assigned to a user.
 export interface AssignmentAssessment {
   progress: {
     survey: string;
@@ -506,14 +426,16 @@ export interface AssignmentAssessment {
   demoData: boolean;
   id: string;
   name: string;
-  /** Mirrors administration `syncStatus`. Only show `"complete"` assignments to users. */
+  /** Mirrors administration syncStatus. Only show "complete" assignments to users. */
   syncStatus?: "pending" | "complete" | "failed";
 }
 
-/** Tracks versions of legal documents using GitHub as a reference point. */
+// Tracks versions of legal documents using GitHub as a reference point.
 export interface Legal {}
 
-/** Permission action types allowed in the system. */
+/**
+ * Permission action types allowed in the system.
+ */
 export type PermissionAction =
   | "create"
   | "read"
@@ -522,7 +444,7 @@ export type PermissionAction =
   | "exclude";
 
 /**
- * Permissions structure within the `system/permissions` document.
+ * Interface for the permissions structure within the system/permissions document.
  * Defines granular permissions for different admin roles.
  */
 export interface RolePermissions {
@@ -544,7 +466,7 @@ export interface RolePermissions {
 }
 
 /**
- * Document in the `system` collection.
+ * Interface for documents in the `system` collection.
  * Currently only contains the permissions document.
  */
 export interface SystemPermissions {
@@ -556,49 +478,45 @@ export interface SystemPermissions {
     participant: RolePermissions;
   };
   updatedAt: Timestamp;
-  /** e.g. `"1.1.0"`. */
-  version: string;
+  version: string; // e.g., "1.1.0"
 }
 
-/** Assessment and task data interfaces. */
+// --- Assessment & Task Data --- interfaces
 
 /**
- * Document in the `tasks` collection.
+ * Interface for documents in the `tasks` collection.
  * Defines tasks used in assessments, including descriptions and variant configurations.
- * Document ID: task identifier (e.g. `matrix-reasoning`).
+ * Document ID: Task identifier (e.g., `matrix-reasoning`).
  */
 export interface TaskDoc {
   description?: string;
-  /** URL. */
-  image?: string;
+  image?: string; // URL
   lastUpdated?: Timestamp;
   name?: string;
   registered?: boolean;
-  taskURL?: string;
+  taskURL?: string; // Optional
 }
 
 /**
- * Document in the `tasks/{taskId}/variants` subcollection.
- * Manages different configurations or versions of a task.
- * Document ID: variant identifier.
+ * Interface for documents in the `tasks/{taskId}/variants` subcollection.
+ * Manages different configurations or versions of a task, allowing for customization of the assessment experience.
+ * Document ID: Variant identifier.
  */
 export interface VariantDoc {
   lastUpdated?: Timestamp;
-  /** e.g. `"default"`, `"adaptive"`. */
-  name?: string;
-  /** Task-specific; variable structure. */
-  params?: Record<string, any>;
+  name?: string; // e.g., "default", "adaptive"
+  params?: Record<string, any>; // Task-specific, variable structure
   registered?: boolean;
-  taskURL?: string;
-  variantURL?: string;
+  taskURL?: string; // Optional
+  variantURL?: string; // Optional
 }
 
-/** Guest and assessment run data interfaces. */
+// --- Guest & Assessment Run Data --- interfaces
 
 /**
- * Document in the `guests` collection.
- * Manages temporary or guest user data for one-off assessments without full registration.
- * Document ID: guest `assessmentUid`.
+ * Interface for documents in the `guests` collection.
+ * Manages temporary or guest user data, often used for one-off assessments without full user registration.
+ * Document ID: Guest assessmentUid.
  */
 export interface GuestDoc {
   age?: number;
@@ -606,23 +524,20 @@ export interface GuestDoc {
   assessmentUid?: string;
   created?: Timestamp;
   lastUpdated?: Timestamp;
-  /** Task IDs interacted with. */
-  tasks?: string[];
+  tasks?: string[]; // Task IDs interacted with
   userType?: "guest";
-  /** Variant IDs assigned. */
-  variants?: string[];
+  variants?: string[]; // Variant IDs assigned
 }
 
 /**
- * Document in the `guests/{guestId}/runs` or `users/{userId}/runs` subcollection.
- * Document ID: unique run ID.
+ * Interface for documents in the `guests/{guestId}/runs` and `users/{userId}/runs` subcollection.
+ * Document ID: Unique Run ID.
  */
 export interface RunDoc {
   assigningOrgs?: string[] | null;
   assignmentId?: string | null;
   completed?: boolean;
-  /** Run ID. */
-  id?: string;
+  id?: string; // Run ID
   readOrgs?: string[] | null;
   reliable?: boolean;
   scores?: {
@@ -648,25 +563,22 @@ export interface RunDoc {
       };
     };
   };
-  /** e.g. `"matrix-reasoning"`. */
-  taskId?: string;
+  taskId?: string; // e.g., "matrix-reasoning"
   timeFinished?: Timestamp;
   timeStarted?: Timestamp;
   userData?: {
-    /** Guest UID. */
-    assessmentUid?: string;
+    assessmentUid?: string; // Guest UID
     variantId?: string;
   };
 }
 
 /**
- * Document in the `guests/{guestId}/runs/{runId}/trials` or
- * `users/{userId}/runs/{runId}/trials` subcollection.
- * Document ID: trial ID or unique identifier within the run.
- * Structure varies significantly based on the parent run's `taskId`.
+ * Interface for documents in the `guests/{guestId}/runs/{runId}/trials` and `users/{userId}/runs/{runId}/trials` subcollection.
+ * Document ID: Trial ID or unique identifier within the run.
+ * Note: The structure of this document varies significantly based on the parent run's taskId.
  */
 export interface TrialDoc {
-  /** Common fields exist, but many are task-dependent. */
+  // Common fields exist, but many are task-dependent.
   [key: string]: any;
   assessment_stage?: string;
   correct?: boolean;

--- a/functions/levante-admin/firestore-schema.ts
+++ b/functions/levante-admin/firestore-schema.ts
@@ -1,9 +1,9 @@
 import * as admin from "firebase-admin";
 
-// Type alias for Firestore Timestamp
+/** Firestore Timestamp type alias. */
 export type Timestamp = admin.firestore.Timestamp;
 
-// Generic structure for organization references used in multiple places
+/** Generic structure for organization references used in multiple places. */
 export interface OrgRefMap {
   classes: string[];
   districts: string[];
@@ -12,30 +12,39 @@ export interface OrgRefMap {
   schools: string[];
 }
 
-// Structure for Assessment Condition Rules within Administrations
+/** Assessment condition rule within an administration. */
 export interface AssessmentConditionRule {
-  field: string; // e.g., "userType"
-  op: string; // e.g., "EQUAL", "AND"
-  value: string | number | boolean | null; // e.g., "student"
+  /** e.g. `"userType"`. */
+  field: string;
+  /** e.g. `"EQUAL"`, `"AND"`. */
+  op: string;
+  /** e.g. `"student"`. */
+  value: string | number | boolean | null;
 }
 
-// Structure for Assessment Conditions within Administrations
+/** Assessment conditions within an administration. */
 export interface AssessmentConditions {
-  assigned: Record<string, unknown>; // Structure needs clarification based on usage
+  /** Structure needs clarification based on usage. */
+  assigned: Record<string, unknown>;
   conditions: AssessmentConditionRule[];
 }
 
-// Structure for individual Assessments within Administrations
+/** Individual assessment within an administration. */
 export interface Assessment {
   conditions: AssessmentConditions;
-  params: Record<string, unknown>; // Parameters specific to the task
-  taskName: string; // e.g., "egma-math"
-  taskId: string; // e.g., "egma-math"
-  variantId: string; // Reference to a task variant
-  variantName: string; // e.g., "es-CO"
+  /** Parameters specific to the task. */
+  params: Record<string, unknown>;
+  /** e.g. `"egma-math"`. */
+  taskName: string;
+  /** e.g. `"egma-math"`. */
+  taskId: string;
+  /** Reference to a task variant. */
+  variantId: string;
+  /** e.g. `"es-CO"`. */
+  variantName: string;
 }
 
-// Structure for Legal information within Administrations and AssignedOrgs
+/** Legal information within administrations and assignedOrgs. */
 export interface LegalInfo {
   amount: string;
   assent: string | null;
@@ -43,25 +52,36 @@ export interface LegalInfo {
   expectedTime: string;
 }
 
-// Interface for documents in the `administrations` collection
-// Stores metadata about each administration (assignment) including the sequence of tasks, involved organizations, and visibility control.
+/**
+ * Document in the `administrations` collection.
+ * Stores metadata about each administration (assignment) including the sequence of
+ * tasks, involved organizations, and visibility control.
+ */
 export interface Administration {
   assessments: Assessment[];
-  classes: string[]; // Document IDs from `classes` collection
-  createdBy: string; // User UID
+  /** Document IDs from the `classes` collection. */
+  classes: string[];
+  /** User UID. */
+  createdBy: string;
   creatorName: string;
   dateClosed: Timestamp;
   dateCreated: Timestamp;
   dateOpened: Timestamp;
-  districts: string[]; // Document IDs from `districts` collection
-  families: string[]; // Document IDs from `families` collection
-  groups: string[]; // Document IDs from `groups` collection
+  /** Document IDs from the `districts` collection. */
+  districts: string[];
+  /** Document IDs from the `families` collection. */
+  families: string[];
+  /** Document IDs from the `groups` collection. */
+  groups: string[];
   legal: LegalInfo;
   minimalOrgs: OrgRefMap;
-  name: string; // Internal name
-  publicName: string; // Public-facing name
+  /** Internal name. */
+  name: string;
+  /** Public-facing name. */
+  publicName: string;
   readOrgs: OrgRefMap;
-  schools: string[]; // Document IDs from `schools` collection
+  /** Document IDs from the `schools` collection. */
+  schools: string[];
   sequential: boolean;
   siteId: string;
   syncChunksCompleted?: number;
@@ -72,63 +92,92 @@ export interface Administration {
   testData: boolean;
 }
 
-// Interface for documents in the `assignedOrgs` subcollection of `administrations`
+/** Document in the `assignedOrgs` subcollection of `administrations`. */
 export interface AssignedOrg {
   administrationId: string;
-  createdBy: string; // User UID of the administration creator
-  dateClosed: Timestamp; // Copied from administration
-  dateCreated: Timestamp; // Timestamp of assignment creation or copied from admin? Needs clarification
-  dateOpened: Timestamp; // Copied from administration
-  legal: LegalInfo; // Copied from administration
-  name: string; // Copied from administration
-  orgId: string; // Document ID of the assigned organization
-  orgType: "classes" | "districts" | "families" | "groups" | "schools"; // Type of the assigned organization
-  publicName: string; // Copied from administration
-  testData: boolean; // Copied from administration
-  timestamp: Timestamp; // Timestamp of assignment creation/update
+  /** User UID of the administration creator. */
+  createdBy: string;
+  /** Copied from administration. */
+  dateClosed: Timestamp;
+  /** Timestamp of assignment creation or copied from admin; needs clarification. */
+  dateCreated: Timestamp;
+  /** Copied from administration. */
+  dateOpened: Timestamp;
+  /** Copied from administration. */
+  legal: LegalInfo;
+  /** Copied from administration. */
+  name: string;
+  /** Document ID of the assigned organization. */
+  orgId: string;
+  /** Type of the assigned organization. */
+  orgType: "classes" | "districts" | "families" | "groups" | "schools";
+  /** Copied from administration. */
+  publicName: string;
+  /** Copied from administration. */
+  testData: boolean;
+  /** Timestamp of assignment creation/update. */
+  timestamp: Timestamp;
 }
 
-// Interface for documents in the `readOrgs` subcollection of `administrations`
+/** Document in the `readOrgs` subcollection of `administrations`. */
 export interface ReadOrg {
   administrationId: string;
-  createdBy: string; // User UID of the administration creator
-  dateClosed: Timestamp; // Copied from administration
-  dateCreated: Timestamp; // Timestamp of assignment creation or copied from admin? Needs clarification
-  dateOpened: Timestamp; // Copied from administration
-  legal: LegalInfo; // Copied from administration
-  name: string; // Copied from administration
-  orgId: string; // Document ID of the assigned organization
-  orgType: "classes" | "districts" | "families" | "groups" | "schools"; // Type of the assigned organization
-  publicName: string; // Copied from administration
-  testData: boolean; // Copied from administration
-  timestamp: Timestamp; // Timestamp of assignment creation/update
+  /** User UID of the administration creator. */
+  createdBy: string;
+  /** Copied from administration. */
+  dateClosed: Timestamp;
+  /** Timestamp of assignment creation or copied from admin; needs clarification. */
+  dateCreated: Timestamp;
+  /** Copied from administration. */
+  dateOpened: Timestamp;
+  /** Copied from administration. */
+  legal: LegalInfo;
+  /** Copied from administration. */
+  name: string;
+  /** Document ID of the assigned organization. */
+  orgId: string;
+  /** Type of the assigned organization. */
+  orgType: "classes" | "districts" | "families" | "groups" | "schools";
+  /** Copied from administration. */
+  publicName: string;
+  /** Copied from administration. */
+  testData: boolean;
+  /** Timestamp of assignment creation/update. */
+  timestamp: Timestamp;
 }
 
-// Interface for the stats subcollection of `administrations`
+/** Document in the `stats` subcollection of `administrations`. */
 export interface Stat {
   assignment: Record<string, number>;
   survey: Record<string, number>;
 }
 
-// Interface for documents in the `classes` collection
-// Details about classes, including school affiliation and optional educational details
+/**
+ * Document in the `classes` collection.
+ * Details about classes, including school affiliation and optional educational details.
+ */
 export interface Class {
   archived: boolean;
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  createdBy: string; // User UID
+  /** User UID. */
+  createdBy: string;
   districtId: string;
-  id: string; // Same as document ID
+  /** Same as document ID. */
+  id: string;
   name: string;
   schoolId: string;
 }
 
-// Interface for documents in the `districts` collection
-// Manages information about districts (sites), including associated schools.
+/**
+ * Document in the `districts` collection.
+ * Manages information about districts (sites), including associated schools.
+ */
 export interface District {
   archived: boolean;
   createdAt: Timestamp;
-  createdBy: string; // User UID
+  /** User UID. */
+  createdBy: string;
   updatedAt: Timestamp;
   name: string;
   tags: string[];
@@ -136,46 +185,67 @@ export interface District {
   schools?: string[];
 }
 
-// Interface for documents in the `groups` collection
-// Purpose: Manages group (cohort) data, potentially representing subgroups within a district (site).
-// This is a catch all type group for when a group of users does not fit into the traditional group type.
+/**
+ * Document in the `groups` collection.
+ * Manages group (cohort) data, potentially representing subgroups within a district (site).
+ * Catch-all type for when a group of users does not fit into a traditional org type.
+ */
 export interface Group {
   archived: boolean;
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  createdBy: string; // User UID
-  parentOrgId: string; // Document ID of the parent organization
-  parentOrgType: "district"; // Type of the parent organization
+  /** User UID. */
+  createdBy: string;
+  /** Document ID of the parent organization. */
+  parentOrgId: string;
+  /** Type of the parent organization. */
+  parentOrgType: "district";
   name: string;
   tags: string[];
 }
 
-// Interface for documents in the `schools` collection
-// Contains data about schools, including their districts.
+/**
+ * Document in the `schools` collection.
+ * Contains data about schools, including their districts.
+ */
 export interface School {
   archived: boolean;
-  classes?: string[]; // Document IDs of classes
+  /** Document IDs of classes. */
+  classes?: string[];
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  createdBy: string; // User UID
+  /** User UID. */
+  createdBy: string;
   districtId: string;
-  id: string; // Same as document ID
+  /** Same as document ID. */
+  id: string;
   name: string;
 }
 
-// --- Org information forms (`formDefinitions` collection and response subcollections) ---
+/**
+ * Org information forms: the `formDefinitions` collection and response subcollections.
+ */
 
-// Interface for documents in the `siteInformation` subcollection of `districts`.
-// Optional subcollection: a district document may or may not have siteInformation.
-// Allowed values for select fields are sourced from the runtime form definition,
-// so they are typed as strings here rather than hardcoded literal unions.
+/**
+ * Document in the `siteInformation` subcollection of `districts`.
+ * Optional subcollection: a district document may or may not have siteInformation.
+ * Allowed values for select fields are sourced from the runtime form definition,
+ * so they are typed as strings here rather than hardcoded literal unions.
+ */
 export interface SiteInformation {
   siteId: string;
+  /**
+   * Document ID of the form definition version this response was collected against
+   * (`formDefinitions/siteInformation/versions/{versionId}`).
+   */
+  formVersion: string;
   sampleApproach: string[];
-  sampleApproachOther?: string; // only populated when sampleApproach includes "other"
+  /** Only populated when `sampleApproach` includes `"other"`. */
+  sampleApproachOther?: string;
   siteRecruitment: string;
   adminApproach: string[];
-  adminApproachOther?: string; // only populated when adminApproach includes "other"
+  /** Only populated when `adminApproach` includes `"other"`. */
+  adminApproachOther?: string;
   testConditions: string;
   equipmentType: string[];
   equipmentDevices: string;
@@ -195,15 +265,22 @@ export interface SiteInformation {
   anythingElse?: string;
 }
 
-// Interface for documents in the `schoolInformation` subcollection of `schools`.
-// Optional subcollection: a school document may or may not have schoolInformation.
-// Allowed values for select fields are sourced from the runtime form definition,
-// so they are typed as strings here rather than hardcoded literal unions.
+/**
+ * Document in the `schoolInformation` subcollection of `schools`.
+ * Optional subcollection: a school document may or may not have schoolInformation.
+ * Allowed values for select fields are sourced from the runtime form definition,
+ * so they are typed as strings here rather than hardcoded literal unions.
+ */
 export interface SchoolInformation {
   siteId: string;
   siteName: string;
   schoolId: string;
   schoolPseudonym: string;
+  /**
+   * Document ID of the form definition version this response was collected against
+   * (`formDefinitions/schoolInformation/versions/{versionId}`).
+   */
+  formVersion: string;
   numStudents: string;
   studentAgeYoungest: number;
   studentAgeOldest: number;
@@ -214,113 +291,145 @@ export interface SchoolInformation {
   schoolReligious: string;
   schoolTuition: string;
   schoolSelectiveness: string[];
-  schoolSelectivenessOther?: string; // only populated when schoolSelectiveness includes "other"
+  /** Only populated when `schoolSelectiveness` includes `"other"`. */
+  schoolSelectivenessOther?: string;
   instructionLanguages: string;
   schoolDayLength: number;
   teacherQuals: string;
 }
 
-// Response field keys shared across org-information forms (site and school).
+/** Response field keys shared across org-information forms (site and school). */
 export type InformationFieldKey =
   | keyof SiteInformation
   | keyof SchoolInformation;
 
-// A single field within an org-information form version. Describes how to render
-// and validate one question. `variableName` matches a SiteInformation or
-// SchoolInformation response property for that form.
+/** Section metadata within a form definition version. */
 export interface FormSectionInfo {
   sectionId: string;
   title: string;
   description: string;
 }
 
+/**
+ * Single field within an org-information form version. Describes how to render and
+ * validate one question. `variableName` matches a `SiteInformation` or
+ * `SchoolInformation` response property for that form.
+ */
 export interface FullInformationFormField {
-  itemId: string; // stable spreadsheet id, e.g. "site_02"
+  /** Stable spreadsheet id, e.g. `"site_02"`. */
+  itemId: string;
   variableName: InformationFieldKey;
   kind: "text" | "number" | "single-select" | "multi-select";
   required: boolean;
   sectionId: string;
   questionText: string;
-  // Value/label pairs for select fields; omitted for text/number fields.
+  /** Value/label pairs for select fields; omitted for text/number fields. */
   options?: { value: string; label: string }[];
-  // Conditional visibility: only render/collect this field when another field's
-  // value satisfies the rule (e.g. show "sampleApproachOther" when
-  // "sampleApproach" includes "other").
+  /**
+   * Conditional visibility: only render/collect this field when another field's
+   * value satisfies the rule (e.g. show `sampleApproachOther` when
+   * `sampleApproach` includes `"other"`).
+   */
   displayLogic?: { field: InformationFieldKey; includes: string };
   infoExample?: string;
   notes?: string;
 }
 
-// Interface for documents in the top-level `formDefinitions` collection.
-// Document ID is the form identifier (e.g. "siteInformation", "schoolInformation").
-// Form-specific field definitions live in the versions subcollection.
+/**
+ * Document in the top-level `formDefinitions` collection.
+ * Document ID is the form identifier (e.g. `"siteInformation"`, `"schoolInformation"`).
+ * Form-specific field definitions live in the `versions` subcollection.
+ */
 export interface FormDefinition {
   currentVersionId: string;
   formDescription: string;
-  // Per-response-field descriptions; keys are SiteInformation or SchoolInformation
-  // property names for this form.
+  /**
+   * Per-response-field descriptions; keys are `SiteInformation` or `SchoolInformation`
+   * property names for this form.
+   */
   fieldsDescription: Record<string, string>;
 }
 
-// Interface for documents in the `versions` subcollection of `formDefinitions`.
-// Immutable snapshot of a published definition (`formDefinitions/{formId}/versions/{versionId}`).
+/**
+ * Document in the `versions` subcollection of `formDefinitions`.
+ * Immutable snapshot of a published definition
+ * (`formDefinitions/{formId}/versions/{versionId}`).
+ */
 export interface FormDefinitionVersion {
   registered: boolean;
   versionNumber: number;
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  liveFrom: Timestamp | null; // null if/when this version is awaiting registration
-  liveUntil: Timestamp | null; // null while this is the current live version
+  /** Null if/when this version is awaiting registration. */
+  liveFrom: Timestamp | null;
+  /** Null while this is the current live version. */
+  liveUntil: Timestamp | null;
   generalPrompt?: string;
   sectionInfo: FormSectionInfo[];
   fullFields: FullInformationFormField[];
 }
 
-// Structure for Claims within UserClaims
-// Manages custom claims for users, facilitating access control based on administrative roles or organizational (Group) affiliations.
+/**
+ * Claims structure within `UserClaims`.
+ * Manages custom claims for users, facilitating access control based on administrative
+ * roles or organizational (group) affiliations.
+ */
 export interface Claims {
   adminOrgs: OrgRefMap;
-  adminUid?: string; // Purpose needs clarification
+  /** Purpose needs clarification. */
+  adminUid?: string;
   assessmentUid?: string;
   minimalAdminOrgs: OrgRefMap;
-  roarUid?: string; // Purpose needs clarification
+  /** Purpose needs clarification. */
+  roarUid?: string;
   super_admin: boolean;
 }
 
-// Interface for documents in the `userClaims` collection (Document ID is User UID)
+/** Document in the `userClaims` collection. Document ID is the user UID. */
 export interface UserClaims {
   claims: Claims;
-  lastUpdated: number; // Unix milliseconds timestamp?
+  /** Unix milliseconds timestamp. */
+  lastUpdated: number;
   testData?: boolean;
 }
 
-// Structure for Admin-specific data within Users
+/** Admin-specific data within `users` documents. */
 export interface AdminData {
-  administrationsCreated: string[]; // IDs of administrations
+  /** IDs of administrations. */
+  administrationsCreated: string[];
 }
 
-// Structure for organizational associations within Users
+/** Organizational associations within `users` documents. */
 export interface OrgAssociationMap {
   all: string[];
   current: string[];
-  dates: Record<string, Timestamp>; // Structure needs clarification
+  /** Structure needs clarification. */
+  dates: Record<string, Timestamp>;
 }
 
-// Structure for user legal document acceptance within Users
+/** User legal document acceptance within `users` documents. */
 export interface UserLegal {
-  assent: Record<string, Timestamp>; // Keyed by form hash/identifier
-  tos: Record<string, Timestamp>; // Keyed by ToS version hash/identifier
+  /** Keyed by form hash/identifier. */
+  assent: Record<string, Timestamp>;
+  /** Keyed by ToS version hash/identifier. */
+  tos: Record<string, Timestamp>;
 }
 
-// Interface for documents in the `users` collection (Document ID is User UID)
-// Stores comprehensive user data including assignments and organizational affiliations.
+/**
+ * Document in the `users` collection. Document ID is the user UID.
+ * Stores comprehensive user data including assignments and organizational affiliations.
+ */
 export interface User {
-  adminData?: AdminData; // only for admin users
+  /** Only for admin users. */
+  adminData?: AdminData;
+  /** Only for participants. */
   assignments?: {
-    // only for participants
-    assigned: string[]; // Document IDs from `administrations` collection that are assigned
-    completed: string[]; // Document IDs from `administrations` collection that are completed
-    started: string[]; // Document IDs from `administrations` collection that are started
+    /** Document IDs from `administrations` that are assigned. */
+    assigned: string[];
+    /** Document IDs from `administrations` that are completed. */
+    completed: string[];
+    /** Document IDs from `administrations` that are started. */
+    started: string[];
   };
   archived: boolean;
   assessmentUid: string;
@@ -333,14 +442,17 @@ export interface User {
   groups: OrgAssociationMap;
   legal: UserLegal;
   schools: OrgAssociationMap;
-  sso?: string; // e.g., "google" only for admin users
+  /** e.g. `"google"`; only for admin users. */
+  sso?: string;
   userType: "admin" | "teacher" | "student" | "parent";
   testData?: boolean;
   roles: { siteId: string; role: string; siteName: string }[];
 }
 
-// Interface for the assignments subcollection of `users`
-// Represents a specific administration assigned to a user.
+/**
+ * Document in the `assignments` subcollection of `users`.
+ * Represents a specific administration assigned to a user.
+ */
 export interface AssignmentAssessment {
   progress: {
     survey: string;
@@ -394,16 +506,14 @@ export interface AssignmentAssessment {
   demoData: boolean;
   id: string;
   name: string;
-  /** Mirrors administration syncStatus. Only show "complete" assignments to users. */
+  /** Mirrors administration `syncStatus`. Only show `"complete"` assignments to users. */
   syncStatus?: "pending" | "complete" | "failed";
 }
 
-// Tracks versions of legal documents using GitHub as a reference point.
+/** Tracks versions of legal documents using GitHub as a reference point. */
 export interface Legal {}
 
-/**
- * Permission action types allowed in the system.
- */
+/** Permission action types allowed in the system. */
 export type PermissionAction =
   | "create"
   | "read"
@@ -412,7 +522,7 @@ export type PermissionAction =
   | "exclude";
 
 /**
- * Interface for the permissions structure within the system/permissions document.
+ * Permissions structure within the `system/permissions` document.
  * Defines granular permissions for different admin roles.
  */
 export interface RolePermissions {
@@ -434,7 +544,7 @@ export interface RolePermissions {
 }
 
 /**
- * Interface for documents in the `system` collection.
+ * Document in the `system` collection.
  * Currently only contains the permissions document.
  */
 export interface SystemPermissions {
@@ -446,45 +556,49 @@ export interface SystemPermissions {
     participant: RolePermissions;
   };
   updatedAt: Timestamp;
-  version: string; // e.g., "1.1.0"
+  /** e.g. `"1.1.0"`. */
+  version: string;
 }
 
-// --- Assessment & Task Data --- interfaces
+/** Assessment and task data interfaces. */
 
 /**
- * Interface for documents in the `tasks` collection.
+ * Document in the `tasks` collection.
  * Defines tasks used in assessments, including descriptions and variant configurations.
- * Document ID: Task identifier (e.g., `matrix-reasoning`).
+ * Document ID: task identifier (e.g. `matrix-reasoning`).
  */
 export interface TaskDoc {
   description?: string;
-  image?: string; // URL
+  /** URL. */
+  image?: string;
   lastUpdated?: Timestamp;
   name?: string;
   registered?: boolean;
-  taskURL?: string; // Optional
+  taskURL?: string;
 }
 
 /**
- * Interface for documents in the `tasks/{taskId}/variants` subcollection.
- * Manages different configurations or versions of a task, allowing for customization of the assessment experience.
- * Document ID: Variant identifier.
+ * Document in the `tasks/{taskId}/variants` subcollection.
+ * Manages different configurations or versions of a task.
+ * Document ID: variant identifier.
  */
 export interface VariantDoc {
   lastUpdated?: Timestamp;
-  name?: string; // e.g., "default", "adaptive"
-  params?: Record<string, any>; // Task-specific, variable structure
+  /** e.g. `"default"`, `"adaptive"`. */
+  name?: string;
+  /** Task-specific; variable structure. */
+  params?: Record<string, any>;
   registered?: boolean;
-  taskURL?: string; // Optional
-  variantURL?: string; // Optional
+  taskURL?: string;
+  variantURL?: string;
 }
 
-// --- Guest & Assessment Run Data --- interfaces
+/** Guest and assessment run data interfaces. */
 
 /**
- * Interface for documents in the `guests` collection.
- * Manages temporary or guest user data, often used for one-off assessments without full user registration.
- * Document ID: Guest assessmentUid.
+ * Document in the `guests` collection.
+ * Manages temporary or guest user data for one-off assessments without full registration.
+ * Document ID: guest `assessmentUid`.
  */
 export interface GuestDoc {
   age?: number;
@@ -492,20 +606,23 @@ export interface GuestDoc {
   assessmentUid?: string;
   created?: Timestamp;
   lastUpdated?: Timestamp;
-  tasks?: string[]; // Task IDs interacted with
+  /** Task IDs interacted with. */
+  tasks?: string[];
   userType?: "guest";
-  variants?: string[]; // Variant IDs assigned
+  /** Variant IDs assigned. */
+  variants?: string[];
 }
 
 /**
- * Interface for documents in the `guests/{guestId}/runs` and `users/{userId}/runs` subcollection.
- * Document ID: Unique Run ID.
+ * Document in the `guests/{guestId}/runs` or `users/{userId}/runs` subcollection.
+ * Document ID: unique run ID.
  */
 export interface RunDoc {
   assigningOrgs?: string[] | null;
   assignmentId?: string | null;
   completed?: boolean;
-  id?: string; // Run ID
+  /** Run ID. */
+  id?: string;
   readOrgs?: string[] | null;
   reliable?: boolean;
   scores?: {
@@ -531,22 +648,25 @@ export interface RunDoc {
       };
     };
   };
-  taskId?: string; // e.g., "matrix-reasoning"
+  /** e.g. `"matrix-reasoning"`. */
+  taskId?: string;
   timeFinished?: Timestamp;
   timeStarted?: Timestamp;
   userData?: {
-    assessmentUid?: string; // Guest UID
+    /** Guest UID. */
+    assessmentUid?: string;
     variantId?: string;
   };
 }
 
 /**
- * Interface for documents in the `guests/{guestId}/runs/{runId}/trials` and `users/{userId}/runs/{runId}/trials` subcollection.
- * Document ID: Trial ID or unique identifier within the run.
- * Note: The structure of this document varies significantly based on the parent run's taskId.
+ * Document in the `guests/{guestId}/runs/{runId}/trials` or
+ * `users/{userId}/runs/{runId}/trials` subcollection.
+ * Document ID: trial ID or unique identifier within the run.
+ * Structure varies significantly based on the parent run's `taskId`.
  */
 export interface TrialDoc {
-  // Common fields exist, but many are task-dependent.
+  /** Common fields exist, but many are task-dependent. */
   [key: string]: any;
   assessment_stage?: string;
   correct?: boolean;

--- a/functions/levante-admin/firestore-schema.ts
+++ b/functions/levante-admin/firestore-schema.ts
@@ -136,74 +136,6 @@ export interface District {
   schools?: string[];
 }
 
-// Interface for documents in the `siteInformation` subcollection of `districts`.
-// Optional subcollection: a district document may or may not have siteInformation.
-// Allowed values for select fields are sourced from the runtime form definition,
-// so they are typed as strings here rather than hardcoded literal unions.
-export interface SiteInformation {
-  sampleApproach: string[];
-  sampleApproachOther?: string; // only populated when sampleApproach includes "other"
-  siteRecruitment: string;
-  adminApproach: string[];
-  adminApproachOther?: string; // only populated when adminApproach includes "other"
-  testConditions: string;
-  equipmentType: string[];
-  equipmentDevices: string;
-  siteGeoArea: string;
-  siteGeoType: string;
-  sitePopulationSize: string;
-  siteRaceEthnicity: string;
-  siteSES: string;
-  siteLifestyle: string;
-  siteTech: string;
-  siteLanguages: string;
-  siteSubsistence: string[];
-  schoolingAgeStart: number;
-  schoolingAgeEnd: number;
-  schoolingProgression: string;
-  schoolingTeacherQuals: string;
-  anythingElse?: string;
-}
-
-// A single field within the Site Information form. Describes how to render and
-// validate one question. Field order is the array order. Built from one row of
-// the site survey source spreadsheet.
-export interface SiteInformationFormField {
-  itemId: string; // stable spreadsheet id, e.g. "site_02"
-  key: keyof SiteInformation; // response property this field populates
-  kind: "text" | "number" | "single-select" | "multi-select";
-  required: boolean;
-  label: string; // question text shown to the user
-  // Value/label pairs for select fields; omitted for text/number fields.
-  options?: { value: string; label: string }[];
-  // Conditional visibility: only render/collect this field when another field's
-  // value satisfies the rule (e.g. show "sampleApproachOther" when
-  // "sampleApproach" includes "other").
-  visibleWhen?: { field: keyof SiteInformation; includes: string };
-  infoExample?: string;
-}
-
-// Interface for the `formDefinitions/siteInformation` document.
-// Holds the current published definition inline plus a pointer to the current version.
-export interface SiteInformationFormDefinition {
-  fields: SiteInformationFormField[];
-  currentVersion: string; // matches a version snapshot document ID
-  updatedAt: Timestamp;
-  updatedBy: string; // User UID
-}
-
-// Interface for the Site Information form version snapshot documents
-// (`formDefinitions/siteInformation/{versionId}`). Immutable snapshot of a
-// published definition, kept so responses stamped with this version stay interpretable.
-export interface SiteInformationFormVersion {
-  fields: SiteInformationFormField[];
-  version: string; // same as document ID
-  createdAt: Timestamp;
-  createdBy: string; // User UID
-  liveFrom: Timestamp; // when this version became the active form
-  liveUntil: Timestamp | null; // when superseded; null while it is the current live version
-}
-
 // Interface for documents in the `groups` collection
 // Purpose: Manages group (cohort) data, potentially representing subgroups within a district (site).
 // This is a catch all type group for when a group of users does not fit into the traditional group type.
@@ -229,6 +161,109 @@ export interface School {
   districtId: string;
   id: string; // Same as document ID
   name: string;
+}
+
+// --- Org information forms (`formDefinitions` collection and response subcollections) ---
+
+// Interface for documents in the `siteInformation` subcollection of `districts`.
+// Optional subcollection: a district document may or may not have siteInformation.
+// Allowed values for select fields are sourced from the runtime form definition,
+// so they are typed as strings here rather than hardcoded literal unions.
+export interface SiteInformation {
+  siteId: string;
+  sampleApproach: string[];
+  sampleApproachOther?: string; // only populated when sampleApproach includes "other"
+  siteRecruitment: string;
+  adminApproach: string[];
+  adminApproachOther?: string; // only populated when adminApproach includes "other"
+  testConditions: string;
+  equipmentType: string[];
+  equipmentDevices: string;
+  siteGeoArea: string;
+  siteGeoType: string;
+  sitePopulationSize: string;
+  siteRaceEthnicity: string;
+  siteSES: string;
+  siteLifestyle: string;
+  siteTech: string;
+  siteLanguages: string;
+  siteSubsistence: string[];
+  schoolingAgeStart: number;
+  schoolingAgeEnd: number;
+  schoolingProgression: string;
+  schoolingTeacherQuals: string;
+  anythingElse?: string;
+}
+
+// Interface for documents in the `schoolInformation` subcollection of `schools`.
+// Optional subcollection: a school document may or may not have schoolInformation.
+// Allowed values for select fields are sourced from the runtime form definition,
+// so they are typed as strings here rather than hardcoded literal unions.
+export interface SchoolInformation {
+  siteId: string;
+  siteName: string;
+  schoolId: string;
+  schoolPseudonym: string;
+  studentAgeYoungest: number;
+  studentAgeOldest: number;
+  numTeachers: string;
+  studentsPerTeacher: number;
+  avgClassSize: string;
+  schoolFunding: string;
+  schoolReligious: string;
+  schoolTuition: string;
+  schoolSelectiveness: string;
+  schoolSelectivenessOther?: string; // only populated when schoolSelectiveness includes "other"
+  instructionLanguages: string;
+  schoolDayLength: number;
+  teacherQuals: string;
+}
+
+// Response field keys shared across org-information forms (site and school).
+export type InformationFieldKey =
+  | keyof SiteInformation
+  | keyof SchoolInformation;
+
+// A single field within an org-information form version. Describes how to render
+// and validate one question. `variableName` matches a SiteInformation or
+// SchoolInformation response property for that form.
+export interface FullInformationFormField {
+  itemId: string; // stable spreadsheet id, e.g. "site_02"
+  variableName: InformationFieldKey;
+  kind: "text" | "number" | "single-select" | "multi-select";
+  required: boolean;
+  questionText: string;
+  // Value/label pairs for select fields; omitted for text/number fields.
+  options?: { value: string; label: string }[];
+  // Conditional visibility: only render/collect this field when another field's
+  // value satisfies the rule (e.g. show "sampleApproachOther" when
+  // "sampleApproach" includes "other").
+  displayLogic?: { field: InformationFieldKey; includes: string };
+  infoExample?: string;
+  notes?: string;
+}
+
+// Interface for documents in the top-level `formDefinitions` collection.
+// Document ID is the form identifier (e.g. "siteInformation", "schoolInformation").
+// Form-specific field definitions live in the versions subcollection.
+export interface FormDefinition {
+  currentVersionId: string;
+  formDescription: string;
+  // Per-response-field descriptions; keys are SiteInformation or SchoolInformation
+  // property names for this form.
+  fieldsDescription: Record<string, string>;
+}
+
+// Interface for documents in the `versions` subcollection of `formDefinitions`.
+// Immutable snapshot of a published definition (`formDefinitions/{formId}/versions/{versionId}`).
+export interface FormDefinitionVersion {
+  registered: boolean;
+  versionNumber: number;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  liveFrom: Timestamp | null; // null if/when this version is awaiting registration
+  liveUntil: Timestamp | null; // null while this is the current live version
+  fullFields: FullInformationFormField[];
 }
 
 // Structure for Claims within UserClaims

--- a/functions/levante-admin/firestore-schema.ts
+++ b/functions/levante-admin/firestore-schema.ts
@@ -204,6 +204,7 @@ export interface SchoolInformation {
   siteName: string;
   schoolId: string;
   schoolPseudonym: string;
+  numStudents: string;
   studentAgeYoungest: number;
   studentAgeOldest: number;
   numTeachers: string;
@@ -212,7 +213,7 @@ export interface SchoolInformation {
   schoolFunding: string;
   schoolReligious: string;
   schoolTuition: string;
-  schoolSelectiveness: string;
+  schoolSelectiveness: string[];
   schoolSelectivenessOther?: string; // only populated when schoolSelectiveness includes "other"
   instructionLanguages: string;
   schoolDayLength: number;
@@ -227,11 +228,18 @@ export type InformationFieldKey =
 // A single field within an org-information form version. Describes how to render
 // and validate one question. `variableName` matches a SiteInformation or
 // SchoolInformation response property for that form.
+export interface FormSectionInfo {
+  sectionId: string;
+  title: string;
+  description: string;
+}
+
 export interface FullInformationFormField {
   itemId: string; // stable spreadsheet id, e.g. "site_02"
   variableName: InformationFieldKey;
   kind: "text" | "number" | "single-select" | "multi-select";
   required: boolean;
+  sectionId: string;
   questionText: string;
   // Value/label pairs for select fields; omitted for text/number fields.
   options?: { value: string; label: string }[];
@@ -263,6 +271,8 @@ export interface FormDefinitionVersion {
   updatedAt: Timestamp;
   liveFrom: Timestamp | null; // null if/when this version is awaiting registration
   liveUntil: Timestamp | null; // null while this is the current live version
+  generalPrompt?: string;
+  sectionInfo: FormSectionInfo[];
   fullFields: FullInformationFormField[];
 }
 

--- a/functions/levante-admin/firestore-schema.ts
+++ b/functions/levante-admin/firestore-schema.ts
@@ -136,6 +136,74 @@ export interface District {
   schools?: string[];
 }
 
+// Interface for documents in the `siteInformation` subcollection of `districts`.
+// Optional subcollection: a district document may or may not have siteInformation.
+// Allowed values for select fields are sourced from the runtime form definition,
+// so they are typed as strings here rather than hardcoded literal unions.
+export interface SiteInformation {
+  sampleApproach: string[];
+  sampleApproachOther?: string; // only populated when sampleApproach includes "other"
+  siteRecruitment: string;
+  adminApproach: string[];
+  adminApproachOther?: string; // only populated when adminApproach includes "other"
+  testConditions: string;
+  equipmentType: string[];
+  equipmentDevices: string;
+  siteGeoArea: string;
+  siteGeoType: string;
+  sitePopulationSize: string;
+  siteRaceEthnicity: string;
+  siteSES: string;
+  siteLifestyle: string;
+  siteTech: string;
+  siteLanguages: string;
+  siteSubsistence: string[];
+  schoolingAgeStart: number;
+  schoolingAgeEnd: number;
+  schoolingProgression: string;
+  schoolingTeacherQuals: string;
+  anythingElse?: string;
+}
+
+// A single field within the Site Information form. Describes how to render and
+// validate one question. Field order is the array order. Built from one row of
+// the site survey source spreadsheet.
+export interface SiteInformationFormField {
+  itemId: string; // stable spreadsheet id, e.g. "site_02"
+  key: keyof SiteInformation; // response property this field populates
+  kind: "text" | "number" | "single-select" | "multi-select";
+  required: boolean;
+  label: string; // question text shown to the user
+  // Value/label pairs for select fields; omitted for text/number fields.
+  options?: { value: string; label: string }[];
+  // Conditional visibility: only render/collect this field when another field's
+  // value satisfies the rule (e.g. show "sampleApproachOther" when
+  // "sampleApproach" includes "other").
+  visibleWhen?: { field: keyof SiteInformation; includes: string };
+  infoExample?: string;
+}
+
+// Interface for the `formDefinitions/siteInformation` document.
+// Holds the current published definition inline plus a pointer to the current version.
+export interface SiteInformationFormDefinition {
+  fields: SiteInformationFormField[];
+  currentVersion: string; // matches a version snapshot document ID
+  updatedAt: Timestamp;
+  updatedBy: string; // User UID
+}
+
+// Interface for the Site Information form version snapshot documents
+// (`formDefinitions/siteInformation/{versionId}`). Immutable snapshot of a
+// published definition, kept so responses stamped with this version stay interpretable.
+export interface SiteInformationFormVersion {
+  fields: SiteInformationFormField[];
+  version: string; // same as document ID
+  createdAt: Timestamp;
+  createdBy: string; // User UID
+  liveFrom: Timestamp; // when this version became the active form
+  liveUntil: Timestamp | null; // when superseded; null while it is the current live version
+}
+
 // Interface for documents in the `groups` collection
 // Purpose: Manages group (cohort) data, potentially representing subgroups within a district (site).
 // This is a catch all type group for when a group of users does not fit into the traditional group type.


### PR DESCRIPTION
## Proposed changes

Adds Firestore schema types for site and school  information responses and the versioned form definitions that will drive the site survey UI.

See seed JSON files for example of what the schema will look like in the new formInformation collection. This information will be queried and used to populate the front-end form; this will allow us to make any necessary form changes by creating a new registered version in firestore rather than pushing dashboard changes. 

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
