### PR TITLE
fix: stop admin provisioning from revoking the new admin's refresh token

### DIFF
--- a/functions/levante-admin/src/users/admin-user.ts
+++ b/functions/levante-admin/src/users/admin-user.ts
@@ -76,7 +76,10 @@ export const createAdminUser = async ({
   const getUserInfo = async (createPassword = false) => {
     const info: CreateRequest = {
       email,
-      emailVerified: false,
+      // See create-administrator.ts: leaving this false makes the first
+      // email-link sign-in mutate the email, which revokes the refresh token
+      // that sign-in just issued.
+      emailVerified: true,
       disabled: false,
       displayName,
     };
@@ -97,8 +100,12 @@ export const createAdminUser = async ({
         `Updating preexisting admin user with ${email} in admin project`
       );
       preExistingUser = true;
+      // Deliberately omits email. The record was just looked up by this
+      // address, so sending it back can only ever be a no-op write, and
+      // Firebase revokes outstanding refresh tokens for any updateUser payload
+      // carrying an email field. Including it means re-provisioning an existing
+      // administrator silently kills that administrator's live session.
       await auth.updateUser(userRecord.uid, {
-        email: userRecord.email || email,
         emailVerified: userRecord.emailVerified || false,
         disabled: false,
         displayName: userRecord.displayName || displayName,

--- a/functions/levante-admin/src/users/create-administrator.ts
+++ b/functions/levante-admin/src/users/create-administrator.ts
@@ -175,7 +175,12 @@ export const _createAdministratorWithRoles = async ({
   } else {
     const createdUser = await auth.createUser({
       email,
-      emailVerified: false,
+      // Administrators get a random password and sign in via email link, and
+      // that first sign-in flips emailVerified. Firebase revokes outstanding
+      // refresh tokens on an email mutation, including the token that same
+      // sign-in just issued, leaving the new admin with a session that dies at
+      // its first token expiry. Verifying up front avoids the mutation.
+      emailVerified: true,
       disabled: false,
       displayName,
       password: uuidv4(),


### PR DESCRIPTION
Backend half of levante-framework/levante-dashboard#1003. Dashboard side: levante-framework/levante-dashboard#1004.

## Background

A site admin on `beta-tubingen-de-sandbox` reported that her cohort and assignment disappeared about an hour into her first session and came back after signing out and in. Nothing was deleted: her refresh tokens were revoked at Jul 30 06:31:11Z, ~1.4s into her first sign-in, so once the ID token hit its one-hour expiry every Firestore read returned 401 and could not recover. The dashboard PR fixes the symptom (surfacing the error and refreshing the token); this PR removes the trigger.

Her auth record is the anomaly among the site's four admins. For every other account `validSince` equals either the creation time or a real password change; hers is 12 hours after creation, matches no password change, and lands within ~1.4s of her first sign-in. She is also the only admin on that site whose `emailVerified` flipped to `true`.

## Changes

**`create-administrator.ts` — provision admins as verified.** This is the path behind the `createAdministrator` callable that created her account. Admins are created with a random UUID password, so the first sign-in is via email link, and that flow marks the email verified. Firebase revokes outstanding refresh tokens on an email mutation — including the refresh token that same sign-in had just issued. The session then works for exactly one token lifetime and dies. Creating the account already verified means that first sign-in mutates nothing.

**`admin-user.ts` — same change on the legacy `createAdministratorAccount` path,** plus drop `email` from the `updateUser` payload for pre-existing admins:

```ts
await auth.updateUser(userRecord.uid, {
-  email: userRecord.email || email,
   emailVerified: userRecord.emailVerified || false,
```

The record is fetched via `getUserByEmail(email)`, so `userRecord.email` always equals `email` and sending it back is by definition a no-op write. It still carries an email field, though, so it still revokes tokens. This did not fire for her on Jul 30, but it means re-running admin provisioning for an existing admin drops that admin's live session into the same broken state.

## Notes for review

Two things worth a second opinion:

1. **`emailVerified: true` asserts verification before the invite is clicked.** I checked: nothing in `functions/` or in the dashboard reads `emailVerified` for authorization — it is only ever written as `false` and reported by `list-user-providers`. So this is inert today, but it is a semantic claim about an address we have not yet proven the admin controls. If you would rather not assert it, the alternative is to leave provisioning alone and rely on the dashboard-side token refresh to absorb the revocation.
2. **The revocation cause is inference, not a logged event.** Identity Platform does not log a revocation reason. The email-link hypothesis is the only one consistent with all four accounts on that site, but it is not directly observed.

The participant paths in `create-users.ts` still use `emailVerified: false` and are intentionally untouched — those users do not sign in by email link.

## Test plan

- [x] `npm run build` — no new type errors (14 pre-existing failures from stale local deps, identical before and after)
- [x] `npm run test:unit` — 53 tests passing
- [x] `prettier --check` clean on both files
- [ ] Manual, dev project: create a new administrator, sign in via the email link, and confirm `validSince` is not bumped and the session survives past one hour
- [ ] Manual, dev project: re-run admin provisioning for an already-signed-in admin and confirm their session keeps working