### PR TITLE
Fix admin user reads by site roles

### DIFF
--- a/__tests__/rules/user-read-site-roles.rules.test.ts
+++ b/__tests__/rules/user-read-site-roles.rules.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, beforeAll, afterAll, beforeEach } from "vitest";
+import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import {
+  createTestEnvironment,
+  setupTestData,
+  createUserWithClaims,
+} from "./test-utils";
+
+const SITE = "siteX";
+const OTHER_SITE = "siteY";
+
+const siteAdminClaims = {
+  rolesSet: ["site_admin"],
+  siteRoles: { [SITE]: ["site_admin"] },
+  siteNames: { [SITE]: "Site X" },
+};
+
+describe("Reading user docs scoped by roles[].siteId", () => {
+  let testEnv: import("@firebase/rules-unit-testing").RulesTestEnvironment;
+
+  beforeAll(async () => {
+    testEnv = await createTestEnvironment();
+  });
+
+  afterAll(async () => {
+    if (testEnv) {
+      await testEnv.cleanup();
+    }
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+
+    await setupTestData(testEnv, async (ctx) => {
+      await ctx
+        .firestore()
+        .doc("system/permissions")
+        .set({
+          permissions: {
+            super_admin: { users: ["create", "read", "update", "delete"] },
+            site_admin: { users: ["create", "read", "update", "delete"] },
+            admin: { users: ["create", "read", "update"] },
+            research_assistant: { users: ["read"] },
+            participant: { users: [] },
+          },
+        });
+
+      await ctx.firestore().doc("users/requestingAdmin").set({
+        userType: "admin",
+        districts: { current: [] },
+        roles: [{ siteId: SITE, role: "site_admin", siteName: "Site X" }],
+      });
+    });
+  });
+
+  test("site admin can read another admin in the same site", async () => {
+    await setupTestData(testEnv, async (ctx) => {
+      await ctx
+        .firestore()
+        .doc("users/creatorAdmin")
+        .set({
+          userType: "admin",
+          displayName: "Creator Admin",
+          districts: { current: [] },
+          roles: [{ siteId: SITE, role: "admin", siteName: "Site X" }],
+        });
+    });
+
+    const admin = createUserWithClaims(
+      testEnv,
+      "requestingAdmin",
+      siteAdminClaims,
+    );
+
+    await assertSucceeds(admin.firestore().doc("users/creatorAdmin").get());
+  });
+
+  test("site admin cannot read an admin scoped to a different site", async () => {
+    await setupTestData(testEnv, async (ctx) => {
+      await ctx
+        .firestore()
+        .doc("users/foreignAdmin")
+        .set({
+          userType: "admin",
+          districts: { current: [] },
+          roles: [{ siteId: OTHER_SITE, role: "admin", siteName: "Site Y" }],
+        });
+    });
+
+    const admin = createUserWithClaims(
+      testEnv,
+      "requestingAdmin",
+      siteAdminClaims,
+    );
+
+    await assertFails(admin.firestore().doc("users/foreignAdmin").get());
+  });
+
+  test("site admin cannot read an admin that has no roles", async () => {
+    await setupTestData(testEnv, async (ctx) => {
+      await ctx.firestore().doc("users/unscopedAdmin").set({
+        userType: "admin",
+        districts: { current: [] },
+        roles: [],
+      });
+    });
+
+    const admin = createUserWithClaims(
+      testEnv,
+      "requestingAdmin",
+      siteAdminClaims,
+    );
+
+    await assertFails(admin.firestore().doc("users/unscopedAdmin").get());
+  });
+
+  test("site admin can still read a participant via districts.current", async () => {
+    await setupTestData(testEnv, async (ctx) => {
+      await ctx
+        .firestore()
+        .doc("users/participant")
+        .set({
+          userType: "student",
+          districts: { current: [SITE] },
+          roles: [{ siteId: SITE, role: "participant", siteName: "Site X" }],
+        });
+    });
+
+    const admin = createUserWithClaims(
+      testEnv,
+      "requestingAdmin",
+      siteAdminClaims,
+    );
+
+    await assertSucceeds(admin.firestore().doc("users/participant").get());
+  });
+
+  test("site admin cannot read a participant in a different site", async () => {
+    await setupTestData(testEnv, async (ctx) => {
+      await ctx
+        .firestore()
+        .doc("users/foreignParticipant")
+        .set({
+          userType: "student",
+          districts: { current: [OTHER_SITE] },
+          roles: [
+            { siteId: OTHER_SITE, role: "participant", siteName: "Site Y" },
+          ],
+        });
+    });
+
+    const admin = createUserWithClaims(
+      testEnv,
+      "requestingAdmin",
+      siteAdminClaims,
+    );
+
+    await assertFails(
+      admin.firestore().doc("users/foreignParticipant").get(),
+    );
+  });
+});

--- a/functions/levante-admin/README.md
+++ b/functions/levante-admin/README.md
@@ -20,6 +20,12 @@ Here's a table describing the purpose of each directory:
 | `users`                   | Functions and utilities related to user management, such as creating, updating, and deleting users.       |
 | `utils`                   | Miscellaneous utility functions and helpers used in multiple other folders.                               |
 
+## Firestore user read rules
+
+Admin user documents may leave `districts.current` empty and record their site membership only in `roles[].siteId`.
+The `users/{uid}` read rule therefore checks `districts.current` first and falls back to `roles[].siteId` when needed,
+so site-scoped admins can read admin users in their own site without gaining access to admins from other sites.
+
 ## Database synchronization
 
 Here we describe ROAR's different databases and expound upon the various

--- a/functions/levante-admin/firestore.rules
+++ b/functions/levante-admin/firestore.rules
@@ -115,9 +115,34 @@ service cloud.firestore {
           && resource.data.parentIds.hasAny([getUid()]);
       }
 
+      function targetUserData() {
+        return get(/databases/$(database)/documents/users/$(uid)).data;
+      }
+
+      // Admin accounts leave districts.current empty and record their site membership
+      // only in roles[].siteId. Bounded to ten entries to match _anySiteWithRole.
+      function siteIdsFromRoles(roles) {
+        return [
+          roles.size() > 0 ? roles[0].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 1 ? roles[1].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 2 ? roles[2].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 3 ? roles[3].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 4 ? roles[4].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 5 ? roles[5].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 6 ? roles[6].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 7 ? roles[7].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 8 ? roles[8].get('siteId', 'nullId') : 'nullId',
+          roles.size() > 9 ? roles[9].get('siteId', 'nullId') : 'nullId'
+        ];
+      }
+
       // TARGET USER SITES (aka districts)
       function getTargetUserSites() {
-        return get(/databases/$(database)/documents/users/$(uid)).data.get(['districts', 'current'], []);
+        let targetData = targetUserData();
+        let districtSites = targetData.get(['districts', 'current'], []);
+        let roles = targetData.get('roles', []);
+        return districtSites.size() > 0 ? districtSites
+          : (roles.size() > 0 ? siteIdsFromRoles(roles) : []);
       }
 
       function canReadUser() {


### PR DESCRIPTION
DRAFT AS A POTENTIAL APPROACH ONLY 

## Summary
- Allow site-scoped admins to read admin user documents whose site membership is stored in `roles[].siteId` when `districts.current` is empty.
- Keep participant reads scoped by `districts.current`, preserving out-of-site access denial.
- Document the Firestore rule behavior and add targeted rules tests for in-site, out-of-site, and unscoped admin user reads.

## Test plan
- [x] `firebase emulators:exec "npx vitest run __tests__/rules/user-read-site-roles.rules.test.ts"`