### PR TITLE
Add caregiver-linking + survey fixtures to the functions-based emulator seeder

### DIFF
--- a/emulator_scripts/function-based-seeders/fixtures.js
+++ b/emulator_scripts/function-based-seeders/fixtures.js
@@ -25,6 +25,7 @@ const ORG_FIXTURES = {
   originalClassName: "3rd Grade - Room 101",
   newClassName: "4th Grade - Room 102",
   cohortName: "Reading Intervention Cohort",
+  caregiverCohortName: "Caregiver Linking Cohort",
 };
 
 const ADMINISTRATION_TEMPLATES = [
@@ -70,6 +71,26 @@ const ADMINISTRATION_TEMPLATES = [
   },
 ];
 
+// Survey administration scoped to the dedicated caregiver-linking cohort. Each
+// survey task carries the same userType condition the dashboard applies, so
+// caregivers receive the caregiver survey and their children the child survey.
+const CAREGIVER_SURVEY_TEMPLATE = {
+  templateId: "caregiver-linking-survey",
+  name: "Caregiver Linking Survey",
+  sequential: false,
+  daysToClose: 90,
+  tasks: [
+    {
+      taskId: "caregiver-survey",
+      assignedCondition: { field: "userType", op: "EQUAL", value: "parent" },
+    },
+    {
+      taskId: "child-survey",
+      assignedCondition: { field: "userType", op: "EQUAL", value: "student" },
+    },
+  ],
+};
+
 const DEFAULT_LEGAL = {
   amount: "0",
   assent: null,
@@ -107,12 +128,54 @@ function chunk(array, size) {
   return chunks;
 }
 
+// Caregivers with 0, 1, and 2 linked children, isolated in their own cohort so
+// they can be targeted by a dedicated survey administration. All created users
+// still belong to the site district (createUsers derives that from siteId), so
+// the linked children also receive the site's student-conditioned assignments.
+function buildCaregiverLinkingRows({ siteId, caregiverCohortId }) {
+  const orgIds = {
+    districts: [siteId],
+    schools: [],
+    classes: [],
+    cohorts: [caregiverCohortId],
+  };
+  const cohortRow = (row) => ({ ...row, orgIds, isTestData: false });
+
+  return [
+    cohortRow({ id: "caregiverNoChild", userType: "caregiver" }),
+    cohortRow({ id: "caregiverOneChild", userType: "caregiver" }),
+    cohortRow({ id: "caregiverTwoChildren", userType: "caregiver" }),
+    cohortRow({
+      id: "childOfOneCaregiver",
+      userType: "child",
+      month: 3,
+      year: 2019,
+      parentId: "caregiverOneChild",
+    }),
+    cohortRow({
+      id: "childOfTwoCaregiversA",
+      userType: "child",
+      month: 4,
+      year: 2019,
+      parentId: "caregiverTwoChildren",
+    }),
+    cohortRow({
+      id: "childOfTwoCaregiversB",
+      userType: "child",
+      month: 5,
+      year: 2020,
+      parentId: "caregiverTwoChildren",
+    }),
+  ];
+}
+
 function buildParticipantRows({
   siteId,
   schoolId,
   originalClassId,
   newClassId,
   cohortId,
+  caregiverCohortId,
   studentCount = 200,
 }) {
   const baseOrgIds = {
@@ -144,6 +207,8 @@ function buildParticipantRows({
         userType: "child",
         month: 1,
         year: 2018,
+        parentId: "parent",
+        teacherId: "teacher",
       },
       originalClassId
     ),
@@ -162,20 +227,25 @@ function buildParticipantRows({
           userType: "child",
           month: (studentNumber % 12) + 1,
           year: Number(CHILD_BIRTH_YEARS[index % CHILD_BIRTH_YEARS.length]),
+          parentId: "parent",
+          teacherId: "teacher",
         },
         studentNumber <= Math.ceil(studentCount / 2)
           ? newClassId
           : originalClassId
       );
     }),
+    ...buildCaregiverLinkingRows({ siteId, caregiverCohortId }),
   ];
 }
 
 module.exports = {
   ADMIN_USERS,
   ADMINISTRATION_TEMPLATES,
+  CAREGIVER_SURVEY_TEMPLATE,
   DEFAULT_LEGAL,
   ORG_FIXTURES,
+  buildCaregiverLinkingRows,
   buildParticipantRows,
   chunk,
   normalizeToLowercase,

--- a/emulator_scripts/function-based-seeders/steps.js
+++ b/emulator_scripts/function-based-seeders/steps.js
@@ -1,6 +1,7 @@
 const {
   ADMIN_USERS,
   ADMINISTRATION_TEMPLATES,
+  CAREGIVER_SURVEY_TEMPLATE,
   DEFAULT_LEGAL,
   ORG_FIXTURES,
   chunk,
@@ -13,8 +14,14 @@ async function createOrgs({
   uid,
   orgFixtures = ORG_FIXTURES,
 }) {
-  const { siteName, schoolName, originalClassName, newClassName, cohortName } =
-    orgFixtures;
+  const {
+    siteName,
+    schoolName,
+    originalClassName,
+    newClassName,
+    cohortName,
+    caregiverCohortName,
+  } = orgFixtures;
 
   const siteId = await upsertOrg(runtime, idToken, {
     name: siteName,
@@ -69,17 +76,30 @@ async function createOrgs({
     parentOrgType: "district",
   });
 
+  const caregiverCohortId = await upsertOrg(runtime, idToken, {
+    name: caregiverCohortName,
+    normalizedName: normalizeToLowercase(caregiverCohortName),
+    type: "groups",
+    tags: ["function-seed", "caregiver-linking"],
+    createdBy: uid,
+    siteId,
+    parentOrgId: siteId,
+    parentOrgType: "district",
+  });
+
   return {
     siteId,
     schoolId,
     originalClassId,
     newClassId,
     cohortId,
+    caregiverCohortId,
     siteName,
     schoolName,
     originalClassName,
     newClassName,
     cohortName,
+    caregiverCohortName,
   };
 }
 
@@ -123,6 +143,9 @@ async function createParticipantUsers({ runtime, userRows, siteId, idToken }) {
   const createdUsers = [];
 
   for (const rows of chunk(userRows, 25)) {
+    // createUsers rejects with "sync-pending" while a prior chunk's users are
+    // still syncing, so wait for the site to settle before each chunk.
+    await waitForSiteReady({ runtime, siteId, idToken });
     const result = await runtime.callFunction(
       "createUsers",
       { users: rows, siteId },
@@ -137,6 +160,32 @@ async function createParticipantUsers({ runtime, userRows, siteId, idToken }) {
   }
 
   return createdUsers;
+}
+
+async function waitForSiteReady({ runtime, siteId, idToken }) {
+  const startedAt = Date.now();
+  const timeoutMs = 120_000;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const status = await runtime.callFunction(
+      "getSyncStatus",
+      { siteId },
+      idToken
+    );
+    if (status?.users?.failed > 0 || status?.assignments?.failed > 0) {
+      throw new Error(
+        `Site ${siteId} has failed sync status: ${JSON.stringify(status)}`
+      );
+    }
+    if (status?.users?.pending === 0 && status?.assignments?.pending === 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+
+  throw new Error(
+    `Timed out waiting for site ${siteId} to be ready for user creation.`
+  );
 }
 
 async function linkParticipantUsers({
@@ -159,8 +208,8 @@ async function linkParticipantUsers({
         userType: row.userType,
         uid: createdUserBySeedId.get(row.id)?.uid,
         ...(row.userType === "child" && {
-          parentId: "parent",
-          teacherId: "teacher",
+          ...(row.parentId && { parentId: row.parentId }),
+          ...(row.teacherId && { teacherId: row.teacherId }),
           month: Number(row.month),
           year: Number(row.year),
         }),
@@ -197,7 +246,8 @@ async function createAdministrations({
   classIds,
   cohortId,
   creatorName,
-  studentCount,
+  childCount,
+  participantCount,
   includeOptionalAdministrationTemplates = false,
   administrationTemplates = ADMINISTRATION_TEMPLATES,
 }) {
@@ -264,9 +314,12 @@ async function createAdministrations({
       );
     }
 
+    // These administrations target the whole site, so every child in the site
+    // (including the caregiver-linked children) matches a student condition,
+    // while an unconditioned administration reaches every participant.
     const expectedAssignmentCount = template.assignedCondition
-      ? studentCount + 1
-      : studentCount + 3;
+      ? childCount
+      : participantCount;
     await waitForAssignmentSync({
       runtime,
       administrationId: result.administrationId,
@@ -281,6 +334,88 @@ async function createAdministrations({
   }
 
   return createdAdministrations;
+}
+
+async function createCaregiverSurveyAdministration({
+  runtime,
+  idToken,
+  siteId,
+  caregiverCohortId,
+  creatorName,
+  expectedAssignmentCount,
+  template = CAREGIVER_SURVEY_TEMPLATE,
+}) {
+  const taskIds = template.tasks.map((task) => task.taskId);
+  const variantsByTaskId = await runtime.getVariantsByTaskIds(taskIds, idToken);
+  const missingTasks = taskIds.filter((taskId) => !variantsByTaskId[taskId]);
+  if (missingTasks.length > 0) {
+    console.log(
+      `Skipping caregiver survey administration; missing registered variants for: ${missingTasks.join(
+        ", "
+      )}`
+    );
+    return null;
+  }
+
+  const assessments = template.tasks.map(({ taskId, assignedCondition }) => {
+    const variant = variantsByTaskId[taskId];
+    return {
+      taskId,
+      variantId: variant.variantId,
+      variantName: variant.variantName,
+      params: variant.params,
+      ...(assignedCondition && {
+        conditions: { assigned: assignedCondition },
+      }),
+    };
+  });
+
+  const now = new Date();
+  const closeDate = new Date(
+    now.getTime() + template.daysToClose * 24 * 60 * 60 * 1000
+  );
+  const result = await runtime.callFunction(
+    "upsertAdministration",
+    {
+      name: template.name,
+      normalizedName: normalizeToLowercase(template.name),
+      assessments,
+      dateOpen: now.toISOString(),
+      dateClose: closeDate.toISOString(),
+      sequential: template.sequential,
+      orgs: {
+        districts: [],
+        schools: [],
+        classes: [],
+        groups: [caregiverCohortId],
+      },
+      isTestData: false,
+      legal: DEFAULT_LEGAL,
+      creatorName,
+      siteId,
+    },
+    idToken
+  );
+
+  if (!result?.administrationId) {
+    throw new Error(
+      `upsertAdministration returned an unexpected response: ${JSON.stringify(
+        result
+      )}`
+    );
+  }
+
+  await waitForAssignmentSync({
+    runtime,
+    administrationId: result.administrationId,
+    expectedCount: expectedAssignmentCount,
+  });
+
+  return {
+    ...template,
+    id: result.administrationId,
+    expectedAssignmentCount,
+  };
 }
 
 async function waitForAssignmentSync({
@@ -307,6 +442,7 @@ async function waitForAssignmentSync({
 module.exports = {
   createAdminUsers,
   createAdministrations,
+  createCaregiverSurveyAdministration,
   createOrgs,
   createParticipantUsers,
   linkParticipantUsers,

--- a/emulator_scripts/function-based-seeders/validation.js
+++ b/emulator_scripts/function-based-seeders/validation.js
@@ -5,7 +5,8 @@ async function validateDashboardVisibleData({
   siteId,
   createdAdministrations,
   idToken,
-  studentCount,
+  participantCount,
+  expectedGroups = 1,
   adminUsers = ADMIN_USERS,
 }) {
   const administrationsResult = await runtime.callFunction(
@@ -54,7 +55,6 @@ async function validateDashboardVisibleData({
     },
     idToken
   );
-  const participantCount = studentCount + 3;
   const visibleSiteUsers = siteUsers.filter((row) => row.document);
   if (visibleSiteUsers.length !== participantCount) {
     throw new Error(
@@ -87,7 +87,7 @@ async function validateDashboardVisibleData({
     districts: 1,
     schools: 1,
     classes: 2,
-    groups: 1,
+    groups: expectedGroups,
     administrations: createdAdministrations.length,
   };
   const actualCounts = {

--- a/emulator_scripts/seed-emulator-functions.js
+++ b/emulator_scripts/seed-emulator-functions.js
@@ -13,6 +13,7 @@ const {
 const {
   createAdminUsers,
   createAdministrations,
+  createCaregiverSurveyAdministration,
   createOrgs,
   createParticipantUsers,
   linkParticipantUsers,
@@ -56,6 +57,18 @@ function printTesterLogins({ createdUsers, userRows }) {
     {
       label: "Parent participant",
       ...userBySeedId.get("parent"),
+    },
+    {
+      label: "Caregiver (no children)",
+      ...userBySeedId.get("caregiverNoChild"),
+    },
+    {
+      label: "Caregiver (one child)",
+      ...userBySeedId.get("caregiverOneChild"),
+    },
+    {
+      label: "Caregiver (two children)",
+      ...userBySeedId.get("caregiverTwoChildren"),
     },
   ].filter((login) => login.email && login.password);
 
@@ -112,8 +125,14 @@ async function main() {
     originalClassId: orgs.originalClassId,
     newClassId: orgs.newClassId,
     cohortId: orgs.cohortId,
+    caregiverCohortId: orgs.caregiverCohortId,
     studentCount: options.studentCount,
   });
+  const childCount = userRows.filter((row) => row.userType === "child").length;
+  const participantCount = userRows.length;
+  const caregiverCohortMemberCount = userRows.filter((row) =>
+    row.orgIds.cohorts?.includes(orgs.caregiverCohortId)
+  ).length;
   const createdUsers = await createParticipantUsers({
     runtime,
     userRows,
@@ -141,10 +160,22 @@ async function main() {
       classIds: [orgs.originalClassId, orgs.newClassId],
       cohortId: orgs.cohortId,
       creatorName: "Super Admin User",
-      studentCount: options.studentCount,
+      childCount,
+      participantCount,
       includeOptionalAdministrationTemplates:
         options.includeOptionalAdministrationTemplates,
     });
+
+    console.log("Creating caregiver survey administration...");
+    const caregiverSurvey = await createCaregiverSurveyAdministration({
+      runtime,
+      idToken,
+      siteId: orgs.siteId,
+      caregiverCohortId: orgs.caregiverCohortId,
+      creatorName: "Super Admin User",
+      expectedAssignmentCount: caregiverCohortMemberCount,
+    });
+    if (caregiverSurvey) createdAdministrations.push(caregiverSurvey);
   } else {
     console.log("Skipping administrations for this seed profile.");
   }
@@ -155,7 +186,8 @@ async function main() {
         siteId: orgs.siteId,
         createdAdministrations,
         idToken,
-        studentCount: options.studentCount,
+        participantCount,
+        expectedGroups: 2,
         adminUsers: ADMIN_USERS,
       })
     : null;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "deploy:levante-admin": "firebase deploy --only functions --prefix ./functions/levante-admin/firebase.json",
     "deploy:levante-admin:assessment-dev": "npm run build && (cd functions/levante-admin && firebase deploy --only functions --project hs-levante-assessment-dev)",
     "dev": "EMULATOR=TRUE firebase emulators:start --import=./emulator_data --export-on-exit=./emulator_data",
+    "dev:clean": "EMULATOR=TRUE firebase emulators:start --import=./emulator_data",
     "emulator:seed": "EMULATOR=1 node emulator_scripts/seed-emulator-functions.js",
     "emulator:seed:legacy": "EMULATOR=1 node emulator_scripts/seed-emulator.js",
     "emulator:seed:functions": "EMULATOR=1 node emulator_scripts/seed-emulator-functions.js",


### PR DESCRIPTION
## Proposed changes

Expands emulator_scripts/function-based-seeders to seed data for testing surveys and caregiver↔child relationships:

- Adds three caregivers (with 0, 1, and 2 linked children) in a dedicated caregiver cohort, plus a `Caregiver Linking Survey` administration that assigns `caregiver-survey`/`child-survey` by user type. (Logins visible in output from `npm run emulator:start:dashboard`.)
- Generalizes administration assignment-count expectations and extends validation to cover the new users, cohort, and survey.
- Adds a `dev:clean` npm script that boots the emulator from ./emulator_data without exporting on exit.

## Types of changes

What types of changes does this pull request introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)