### PR TITLE
Add loadFormDefinitions and saveOrgInformation for site/school forms

### DIFF
--- a/__tests__/e2e/forms/load-form-definitions.e2e.test.ts
+++ b/__tests__/e2e/forms/load-form-definitions.e2e.test.ts
@@ -1,0 +1,274 @@
+import type {
+  LoadFormDefinitionsParams,
+  LoadFormDefinitionsResult,
+} from "@levante-framework/levante-zod";
+import type { HttpsCallable } from "firebase/functions";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  adminDb,
+  clearAuth,
+  clearFirestore,
+  getClient,
+  signInAs,
+} from "../app";
+
+const SITE = "site-1";
+const SCHOOL = "school-1";
+const UID = "u-user";
+
+const validSiteLoad = (): LoadFormDefinitionsParams => ({
+  orgType: "site",
+  orgId: SITE,
+});
+
+const siteFields = [
+  {
+    itemId: "site_01",
+    variableName: "sampleApproach",
+    kind: "multi-select" as const,
+    required: true,
+    sectionId: "sampleRecruit",
+    questionText: "How did you sample?",
+  },
+];
+
+const schoolFields = [
+  {
+    itemId: "school_01",
+    variableName: "numTeachers",
+    kind: "single-select" as const,
+    required: true,
+    sectionId: "staff",
+    questionText: "How many teachers?",
+  },
+];
+
+const siteVersion = {
+  registered: true,
+  versionNumber: 1,
+  generalPrompt: "Please complete.",
+  sectionInfo: [
+    {
+      sectionId: "sampleRecruit",
+      title: "Sampling",
+      description: "How you sampled",
+    },
+  ],
+  fullFields: siteFields,
+};
+
+async function seedSite() {
+  await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+}
+
+async function seedSchool() {
+  await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+  await adminDb
+    .doc(`schools/${SCHOOL}`)
+    .set({ name: "School 1", districtId: SITE });
+}
+
+async function seedForm(
+  formId: "siteInformation" | "schoolInformation",
+  definition: Record<string, unknown>,
+  versions: Record<string, Record<string, unknown>>
+) {
+  await adminDb.doc(`formDefinitions/${formId}`).set(definition);
+  await Promise.all(
+    Object.entries(versions).map(([id, data]) =>
+      adminDb.doc(`formDefinitions/${formId}/versions/${id}`).set(data)
+    )
+  );
+}
+
+describe("loadFormDefinitions (e2e)", () => {
+  let client: ReturnType<typeof getClient>;
+  let loadFormDefinitions: HttpsCallable<
+    LoadFormDefinitionsParams,
+    LoadFormDefinitionsResult
+  >;
+
+  beforeEach(async () => {
+    await Promise.all([clearFirestore(), clearAuth()]);
+    client = getClient();
+    loadFormDefinitions = client.call<
+      LoadFormDefinitionsParams,
+      LoadFormDefinitionsResult
+    >("loadFormDefinitions");
+  });
+
+  afterEach(() => client.cleanup());
+
+  it("rejects unauthenticated callers", async () => {
+    await expect(loadFormDefinitions(validSiteLoad())).rejects.toMatchObject({
+      code: "functions/unauthenticated",
+    });
+  });
+
+  it("rejects invalid input with a per-field details payload", async () => {
+    await signInAs(client, UID, {});
+    await expect(
+      // @ts-expect-error intentionally missing orgId
+      loadFormDefinitions({ orgType: "site" })
+    ).rejects.toMatchObject({
+      code: "functions/invalid-argument",
+      details: {
+        code: "schema",
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: "orgId",
+            message: expect.any(String),
+          }),
+        ]),
+      },
+    });
+  });
+
+  it("rejects when the org document does not exist", async () => {
+    await signInAs(client, UID, {});
+
+    await expect(loadFormDefinitions(validSiteLoad())).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
+
+  it("rejects when the form definition does not exist", async () => {
+    await signInAs(client, UID, {});
+    await seedSite();
+
+    await expect(loadFormDefinitions(validSiteLoad())).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
+
+  it("rejects when there is no registered version", async () => {
+    await signInAs(client, UID, {});
+    await seedSite();
+    await seedForm(
+      "siteInformation",
+      {},
+      {
+        draft: { ...siteVersion, registered: false },
+      }
+    );
+
+    await expect(loadFormDefinitions(validSiteLoad())).rejects.toMatchObject({
+      code: "functions/failed-precondition",
+    });
+  });
+
+  it("returns the currentVersionId when that version is registered", async () => {
+    await signInAs(client, UID, {});
+    await seedSite();
+    await seedForm(
+      "siteInformation",
+      {
+        currentVersionId: "v1",
+        formDescription: "Site form",
+        fieldsDescription: { sampleApproach: "sampling" },
+      },
+      {
+        v1: siteVersion,
+        v2: { ...siteVersion, versionNumber: 2, fullFields: [] },
+      }
+    );
+
+    const { data } = await loadFormDefinitions(validSiteLoad());
+    expect(data).toEqual({
+      formId: "siteInformation",
+      versionId: "v1",
+      versionNumber: 1,
+      formDescription: "Site form",
+      fieldsDescription: { sampleApproach: "sampling" },
+      generalPrompt: "Please complete.",
+      sectionInfo: siteVersion.sectionInfo,
+      fullFields: siteFields,
+      orgType: "site",
+      orgId: SITE,
+      savedResponses: [],
+    });
+  });
+
+  it("falls back to the highest registered versionNumber when currentVersionId is missing", async () => {
+    await signInAs(client, UID, {});
+    await seedSite();
+    await seedForm(
+      "siteInformation",
+      { formDescription: "Site form" },
+      {
+        v1: siteVersion,
+        v2: {
+          ...siteVersion,
+          versionNumber: 2,
+          fullFields: [{ ...siteFields[0], variableName: "siteRecruitment" }],
+        },
+      }
+    );
+
+    const { data } = await loadFormDefinitions(validSiteLoad());
+    expect(data.versionId).toBe("v2");
+    expect(data.versionNumber).toBe(2);
+    expect(data.fullFields).toEqual([
+      { ...siteFields[0], variableName: "siteRecruitment" },
+    ]);
+    expect(data.savedResponses).toEqual([]);
+  });
+
+  it("falls back when currentVersionId points to an unregistered version", async () => {
+    await signInAs(client, UID, {});
+    await seedSite();
+    await seedForm(
+      "siteInformation",
+      { currentVersionId: "draft" },
+      {
+        draft: { ...siteVersion, registered: false, versionNumber: 3 },
+        v1: siteVersion,
+        v2: { ...siteVersion, versionNumber: 2 },
+      }
+    );
+
+    const { data } = await loadFormDefinitions(validSiteLoad());
+    expect(data.versionId).toBe("v2");
+    expect(data.versionNumber).toBe(2);
+  });
+
+  it("loads schoolInformation for a school org", async () => {
+    await signInAs(client, UID, {});
+    await seedSchool();
+    await seedForm(
+      "schoolInformation",
+      {
+        currentVersionId: "v1",
+        formDescription: "School form",
+        fieldsDescription: {},
+      },
+      {
+        v1: {
+          registered: true,
+          versionNumber: 1,
+          generalPrompt: "",
+          sectionInfo: [],
+          fullFields: schoolFields,
+        },
+      }
+    );
+
+    const { data } = await loadFormDefinitions({
+      orgType: "school",
+      orgId: SCHOOL,
+    });
+    expect(data).toEqual({
+      formId: "schoolInformation",
+      versionId: "v1",
+      versionNumber: 1,
+      formDescription: "School form",
+      fieldsDescription: {},
+      generalPrompt: "",
+      sectionInfo: [],
+      fullFields: schoolFields,
+      orgType: "school",
+      orgId: SCHOOL,
+      savedResponses: [],
+    });
+  });
+});

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -2,6 +2,7 @@ import type {
   SaveOrgInformationParams,
   SaveOrgInformationResult,
 } from "@levante-framework/levante-zod";
+import { Timestamp, type DocumentData } from "firebase-admin/firestore";
 import type { HttpsCallable } from "firebase/functions";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -68,6 +69,18 @@ const siteFields = [
   },
   { variableName: "siteRecruitment", kind: "text" as const, required: true },
 ];
+
+function dataWithoutTimestamps(data: DocumentData | undefined) {
+  expect(data).toBeDefined();
+  const { createdAt, updatedAt, ...rest } = data!;
+  expect(createdAt).toBeInstanceOf(Timestamp);
+  expect(updatedAt).toBeInstanceOf(Timestamp);
+  return {
+    rest,
+    createdAt: createdAt as Timestamp,
+    updatedAt: updatedAt as Timestamp,
+  };
+}
 
 const schoolFields = [
   {
@@ -256,9 +269,11 @@ describe("saveOrgInformation (e2e)", () => {
     const snap = await adminDb
       .doc(`districts/${SITE}/siteInformation/version-1`)
       .get();
-    expect(snap.data()).toEqual({
+    const first = dataWithoutTimestamps(snap.data());
+    expect(first.rest).toEqual({
       sampleApproach: ["other"],
       sampleApproachOther: "word of mouth",
+      siteId: SITE,
       formVersion: "version-1",
       status: "draft",
     });
@@ -274,13 +289,16 @@ describe("saveOrgInformation (e2e)", () => {
     const merged = await adminDb
       .doc(`districts/${SITE}/siteInformation/version-1`)
       .get();
-    expect(merged.data()).toEqual({
+    const second = dataWithoutTimestamps(merged.data());
+    expect(second.rest).toEqual({
       sampleApproach: ["other"],
       sampleApproachOther: "word of mouth",
       siteRecruitment: "email",
+      siteId: SITE,
       formVersion: "version-1",
       status: "complete",
     });
+    expect(second.createdAt.isEqual(first.createdAt)).toBe(true);
   });
 
   it("rejects complete when a required field is missing", async () => {
@@ -349,6 +367,38 @@ describe("saveOrgInformation (e2e)", () => {
     expect(data.status).toBe("complete");
   });
 
+  it("ignores a late draft after the form is complete", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await saveOrgInformation({
+      orgType: "site",
+      orgId: SITE,
+      formVersion: "version-1",
+      responses: {
+        sampleApproach: ["convenience"],
+        siteRecruitment: "email",
+      },
+      status: "complete",
+    });
+
+    const { data } = await saveOrgInformation(validSiteDraft());
+    expect(data.status).toBe("complete");
+
+    const snap = await adminDb
+      .doc(`districts/${SITE}/siteInformation/version-1`)
+      .get();
+    expect(dataWithoutTimestamps(snap.data()).rest).toEqual({
+      sampleApproach: ["convenience"],
+      siteRecruitment: "email",
+      siteId: SITE,
+      formVersion: "version-1",
+      status: "complete",
+    });
+  });
+
   it("deletes Other text when Other is unselected and the field is sent as null", async () => {
     await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
     await seedSuperAdminClaims(SUPER_ADMIN_UID);
@@ -370,8 +420,9 @@ describe("saveOrgInformation (e2e)", () => {
     const snap = await adminDb
       .doc(`districts/${SITE}/siteInformation/version-1`)
       .get();
-    expect(snap.data()).toEqual({
+    expect(dataWithoutTimestamps(snap.data()).rest).toEqual({
       sampleApproach: ["convenience"],
+      siteId: SITE,
       formVersion: "version-1",
       status: "draft",
     });
@@ -394,7 +445,8 @@ describe("saveOrgInformation (e2e)", () => {
     const snap = await adminDb
       .doc(`districts/${SITE}/siteInformation/version-1`)
       .get();
-    expect(snap.data()).toEqual({
+    expect(dataWithoutTimestamps(snap.data()).rest).toEqual({
+      siteId: SITE,
       formVersion: "version-1",
       status: "draft",
     });
@@ -403,7 +455,10 @@ describe("saveOrgInformation (e2e)", () => {
   it("merges school responses onto schools/{orgId}/schoolInformation/version-2", async () => {
     await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
     await seedSuperAdminClaims(SUPER_ADMIN_UID);
-    await adminDb.doc(`schools/${SCHOOL}`).set({ name: "School 1" });
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await adminDb
+      .doc(`schools/${SCHOOL}`)
+      .set({ name: "School 1", districtId: SITE });
     await seedFormVersion("schoolInformation", "version-2", schoolFields);
 
     const { data } = await saveOrgInformation({
@@ -418,8 +473,12 @@ describe("saveOrgInformation (e2e)", () => {
     const snap = await adminDb
       .doc(`schools/${SCHOOL}/schoolInformation/version-2`)
       .get();
-    expect(snap.data()).toEqual({
+    expect(dataWithoutTimestamps(snap.data()).rest).toEqual({
       numTeachers: "10_to_24",
+      schoolId: SCHOOL,
+      siteId: SITE,
+      schoolPseudonym: "School 1",
+      siteName: "Site 1",
       formVersion: "version-2",
       status: "draft",
     });

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -484,6 +484,47 @@ describe("saveOrgInformation (e2e)", () => {
     });
   });
 
+  it("rejects when the school document has no districtId", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await adminDb.doc(`schools/${SCHOOL}`).set({ name: "School 1" });
+    await seedFormVersion("schoolInformation", "version-2", schoolFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "school",
+        orgId: SCHOOL,
+        formVersion: "version-2",
+        responses: { numTeachers: "10_to_24" },
+        status: "draft",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
+
+  it("rejects when the school's district document does not exist", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb
+      .doc(`schools/${SCHOOL}`)
+      .set({ name: "School 1", districtId: SITE });
+    await seedFormVersion("schoolInformation", "version-2", schoolFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "school",
+        orgId: SCHOOL,
+        formVersion: "version-2",
+        responses: { numTeachers: "10_to_24" },
+        status: "draft",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
+
   it("rejects when the school document has no name", async () => {
     await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
     await seedSuperAdminClaims(SUPER_ADMIN_UID);

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -483,4 +483,46 @@ describe("saveOrgInformation (e2e)", () => {
       status: "draft",
     });
   });
+
+  it("rejects when the school document has no name", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await adminDb.doc(`schools/${SCHOOL}`).set({ districtId: SITE });
+    await seedFormVersion("schoolInformation", "version-2", schoolFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "school",
+        orgId: SCHOOL,
+        formVersion: "version-2",
+        responses: { numTeachers: "10_to_24" },
+        status: "draft",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
+
+  it("rejects when the school's district document has no name", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({});
+    await adminDb
+      .doc(`schools/${SCHOOL}`)
+      .set({ name: "School 1", districtId: SITE });
+    await seedFormVersion("schoolInformation", "version-2", schoolFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "school",
+        orgId: SCHOOL,
+        formVersion: "version-2",
+        responses: { numTeachers: "10_to_24" },
+        status: "draft",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
 });

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -1,3 +1,7 @@
+import type {
+  SaveOrgInformationParams,
+  SaveOrgInformationResult,
+} from "@levante-framework/levante-zod";
 import type { HttpsCallable } from "firebase/functions";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -12,22 +16,6 @@ const SITE = "site-1";
 const SCHOOL = "school-1";
 const SUPER_ADMIN_UID = "u-super";
 const SITE_ADMIN_UID = "u-admin";
-
-type SaveOrgInformationParams = {
-  orgType: "site" | "school";
-  orgId: string;
-  formVersion: string;
-  responses: Record<string, unknown>;
-  status: "draft" | "submitted";
-};
-
-type SaveOrgInformationResult = {
-  orgType: "site" | "school";
-  orgId: string;
-  formVersion: string;
-  status: "draft" | "submitted";
-  path: string;
-};
 
 const validSiteDraft = (): SaveOrgInformationParams => ({
   orgType: "site",

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -384,19 +384,27 @@ describe("saveOrgInformation (e2e)", () => {
       status: "complete",
     });
 
+    const completeSnap = await adminDb
+      .doc(`districts/${SITE}/siteInformation/version-1`)
+      .get();
+    const before = dataWithoutTimestamps(completeSnap.data());
+
     const { data } = await saveOrgInformation(validSiteDraft());
     expect(data.status).toBe("complete");
 
     const snap = await adminDb
       .doc(`districts/${SITE}/siteInformation/version-1`)
       .get();
-    expect(dataWithoutTimestamps(snap.data()).rest).toEqual({
+    const after = dataWithoutTimestamps(snap.data());
+    expect(after.rest).toEqual({
       sampleApproach: ["convenience"],
       siteRecruitment: "email",
       siteId: SITE,
       formVersion: "version-1",
       status: "complete",
     });
+    expect(after.createdAt.isEqual(before.createdAt)).toBe(true);
+    expect(after.updatedAt.isEqual(before.updatedAt)).toBe(true);
   });
 
   it("deletes Other text when Other is unselected and the field is sent as null", async () => {

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -44,10 +44,12 @@ async function seedFormVersion(
     required?: boolean;
     options?: { value: string; label: string }[];
     displayLogic?: { field: string; includes: string };
-  }[]
+  }[],
+  registered = true
 ) {
   await adminDb.doc(`formDefinitions/${formId}/versions/${formVersion}`).set({
     fullFields,
+    registered,
   });
 }
 
@@ -171,6 +173,19 @@ describe("saveOrgInformation (e2e)", () => {
 
     await expect(saveOrgInformation(validSiteDraft())).rejects.toMatchObject({
       code: "functions/not-found",
+    });
+  });
+
+  it("rejects when the form version is not registered", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields, false);
+
+    const draft = validSiteDraft();
+    await expect(saveOrgInformation(draft)).rejects.toMatchObject({
+      code: "functions/failed-precondition",
+      message: `Form version "${draft.formVersion}" is not registered.`,
     });
   });
 
@@ -325,6 +340,29 @@ describe("saveOrgInformation (e2e)", () => {
     expect(snap.exists).toBe(false);
   });
 
+  it("rejects complete when a required text field is only whitespace", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "site",
+        orgId: SITE,
+        formVersion: "version-1",
+        responses: {
+          sampleApproach: ["convenience"],
+          siteRecruitment: "   ",
+        },
+        status: "complete",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/failed-precondition",
+      message: "Required fields are missing: siteRecruitment",
+    });
+  });
+
   it("rejects complete when Other is selected without Other text", async () => {
     await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
     await seedSuperAdminClaims(SUPER_ADMIN_UID);
@@ -405,6 +443,48 @@ describe("saveOrgInformation (e2e)", () => {
     });
     expect(after.createdAt.isEqual(before.createdAt)).toBe(true);
     expect(after.updatedAt.isEqual(before.updatedAt)).toBe(true);
+  });
+
+  it("ignores a late school draft even if the school name is later missing", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await adminDb
+      .doc(`schools/${SCHOOL}`)
+      .set({ name: "School 1", districtId: SITE });
+    await seedFormVersion("schoolInformation", "version-2", schoolFields);
+
+    await saveOrgInformation({
+      orgType: "school",
+      orgId: SCHOOL,
+      formVersion: "version-2",
+      responses: { numTeachers: "10_to_24" },
+      status: "complete",
+    });
+
+    await adminDb.doc(`schools/${SCHOOL}`).set({ districtId: SITE });
+
+    const { data } = await saveOrgInformation({
+      orgType: "school",
+      orgId: SCHOOL,
+      formVersion: "version-2",
+      responses: { numTeachers: "10_to_24" },
+      status: "draft",
+    });
+    expect(data.status).toBe("complete");
+
+    const snap = await adminDb
+      .doc(`schools/${SCHOOL}/schoolInformation/version-2`)
+      .get();
+    expect(dataWithoutTimestamps(snap.data()).rest).toEqual({
+      numTeachers: "10_to_24",
+      schoolId: SCHOOL,
+      siteId: SITE,
+      schoolPseudonym: "School 1",
+      siteName: "Site 1",
+      formVersion: "version-2",
+      status: "complete",
+    });
   });
 
   it("deletes Other text when Other is unselected and the field is sent as null", async () => {
@@ -509,6 +589,7 @@ describe("saveOrgInformation (e2e)", () => {
       })
     ).rejects.toMatchObject({
       code: "functions/not-found",
+      message: `districtId was not found on schools document "${SCHOOL}".`,
     });
   });
 
@@ -530,6 +611,7 @@ describe("saveOrgInformation (e2e)", () => {
       })
     ).rejects.toMatchObject({
       code: "functions/not-found",
+      message: `districts document "${SITE}" was not found.`,
     });
   });
 
@@ -550,6 +632,30 @@ describe("saveOrgInformation (e2e)", () => {
       })
     ).rejects.toMatchObject({
       code: "functions/not-found",
+      message: `name was not found on schools document "${SCHOOL}".`,
+    });
+  });
+
+  it("rejects when the school name is blank", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await adminDb
+      .doc(`schools/${SCHOOL}`)
+      .set({ name: "   ", districtId: SITE });
+    await seedFormVersion("schoolInformation", "version-2", schoolFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "school",
+        orgId: SCHOOL,
+        formVersion: "version-2",
+        responses: { numTeachers: "10_to_24" },
+        status: "draft",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/not-found",
+      message: `name was not found on schools document "${SCHOOL}".`,
     });
   });
 
@@ -572,6 +678,7 @@ describe("saveOrgInformation (e2e)", () => {
       })
     ).rejects.toMatchObject({
       code: "functions/not-found",
+      message: `name was not found on districts document "${SITE}".`,
     });
   });
 });

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -1,0 +1,186 @@
+import type { HttpsCallable } from "firebase/functions";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  adminDb,
+  clearAuth,
+  clearFirestore,
+  getClient,
+  signInAs,
+} from "../app";
+
+const SITE = "site-1";
+const SCHOOL = "school-1";
+const SUPER_ADMIN_UID = "u-super";
+const SITE_ADMIN_UID = "u-admin";
+
+type SaveOrgInformationParams = {
+  orgType: "site" | "school";
+  orgId: string;
+  formVersion: string;
+  responses: Record<string, unknown>;
+  status: "draft" | "submitted";
+};
+
+type SaveOrgInformationResult = {
+  orgType: "site" | "school";
+  orgId: string;
+  formVersion: string;
+  status: "draft" | "submitted";
+  path: string;
+};
+
+const validSiteDraft = (): SaveOrgInformationParams => ({
+  orgType: "site",
+  orgId: SITE,
+  formVersion: "version-1",
+  responses: { sampleApproach: ["other"], sampleApproachOther: "word of mouth" },
+  status: "draft",
+});
+
+async function seedSuperAdminClaims(uid: string) {
+  await adminDb.doc(`userClaims/${uid}`).set({
+    claims: { super_admin: true },
+  });
+}
+
+describe("saveOrgInformation (e2e)", () => {
+  let client: ReturnType<typeof getClient>;
+  let saveOrgInformation: HttpsCallable<
+    SaveOrgInformationParams,
+    SaveOrgInformationResult
+  >;
+
+  beforeEach(async () => {
+    await Promise.all([clearFirestore(), clearAuth()]);
+    client = getClient();
+    saveOrgInformation = client.call<
+      SaveOrgInformationParams,
+      SaveOrgInformationResult
+    >("saveOrgInformation");
+  });
+
+  afterEach(() => client.cleanup());
+
+  it("rejects unauthenticated callers", async () => {
+    await expect(saveOrgInformation(validSiteDraft())).rejects.toMatchObject({
+      code: "functions/unauthenticated",
+    });
+  });
+
+  it("rejects invalid input with a per-field details payload", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await expect(
+      // @ts-expect-error intentionally missing orgId
+      saveOrgInformation({
+        orgType: "site",
+        formVersion: "version-1",
+        responses: {},
+        status: "draft",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/invalid-argument",
+      details: {
+        code: "schema",
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: "orgId",
+            message: expect.any(String),
+          }),
+        ]),
+      },
+    });
+  });
+
+  it("rejects callers who are not super admins", async () => {
+    await signInAs(client, SITE_ADMIN_UID, {
+      useNewPermissions: true,
+      siteRoles: { [SITE]: ["site_admin"] },
+    });
+    await adminDb.doc(`userClaims/${SITE_ADMIN_UID}`).set({
+      claims: { super_admin: false },
+    });
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+
+    await expect(saveOrgInformation(validSiteDraft())).rejects.toMatchObject({
+      code: "functions/permission-denied",
+    });
+  });
+
+  it("rejects when the org document does not exist", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+
+    await expect(saveOrgInformation(validSiteDraft())).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
+
+  it("merges site responses onto districts/{orgId}/siteInformation/response", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+
+    const { data } = await saveOrgInformation(validSiteDraft());
+    expect(data).toEqual({
+      orgType: "site",
+      orgId: SITE,
+      formVersion: "version-1",
+      status: "draft",
+      path: `districts/${SITE}/siteInformation/response`,
+    });
+
+    const snap = await adminDb
+      .doc(`districts/${SITE}/siteInformation/response`)
+      .get();
+    expect(snap.data()).toEqual({
+      sampleApproach: ["other"],
+      sampleApproachOther: "word of mouth",
+      formVersion: "version-1",
+      status: "draft",
+    });
+
+    await saveOrgInformation({
+      orgType: "site",
+      orgId: SITE,
+      formVersion: "version-1",
+      responses: { siteRecruitment: "email" },
+      status: "submitted",
+    });
+
+    const merged = await adminDb
+      .doc(`districts/${SITE}/siteInformation/response`)
+      .get();
+    expect(merged.data()).toEqual({
+      sampleApproach: ["other"],
+      sampleApproachOther: "word of mouth",
+      siteRecruitment: "email",
+      formVersion: "version-1",
+      status: "submitted",
+    });
+  });
+
+  it("merges school responses onto schools/{orgId}/schoolInformation/response", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`schools/${SCHOOL}`).set({ name: "School 1" });
+
+    const { data } = await saveOrgInformation({
+      orgType: "school",
+      orgId: SCHOOL,
+      formVersion: "version-2",
+      responses: { numTeachers: "12" },
+      status: "draft",
+    });
+
+    expect(data.path).toBe(`schools/${SCHOOL}/schoolInformation/response`);
+    const snap = await adminDb
+      .doc(`schools/${SCHOOL}/schoolInformation/response`)
+      .get();
+    expect(snap.data()).toEqual({
+      numTeachers: "12",
+      formVersion: "version-2",
+      status: "draft",
+    });
+  });
+});

--- a/__tests__/e2e/forms/save-org-information.e2e.test.ts
+++ b/__tests__/e2e/forms/save-org-information.e2e.test.ts
@@ -21,7 +21,10 @@ const validSiteDraft = (): SaveOrgInformationParams => ({
   orgType: "site",
   orgId: SITE,
   formVersion: "version-1",
-  responses: { sampleApproach: ["other"], sampleApproachOther: "word of mouth" },
+  responses: {
+    sampleApproach: ["other"],
+    sampleApproachOther: "word of mouth",
+  },
   status: "draft",
 });
 
@@ -30,6 +33,50 @@ async function seedSuperAdminClaims(uid: string) {
     claims: { super_admin: true },
   });
 }
+
+async function seedFormVersion(
+  formId: "siteInformation" | "schoolInformation",
+  formVersion: string,
+  fullFields: {
+    variableName: string;
+    kind: "text" | "number" | "single-select" | "multi-select";
+    required?: boolean;
+    options?: { value: string; label: string }[];
+    displayLogic?: { field: string; includes: string };
+  }[]
+) {
+  await adminDb.doc(`formDefinitions/${formId}/versions/${formVersion}`).set({
+    fullFields,
+  });
+}
+
+const siteFields = [
+  {
+    variableName: "sampleApproach",
+    kind: "multi-select" as const,
+    required: true,
+    options: [
+      { value: "other", label: "Other" },
+      { value: "convenience", label: "Convenience" },
+    ],
+  },
+  {
+    variableName: "sampleApproachOther",
+    kind: "text" as const,
+    required: true,
+    displayLogic: { field: "sampleApproach", includes: "other" },
+  },
+  { variableName: "siteRecruitment", kind: "text" as const, required: true },
+];
+
+const schoolFields = [
+  {
+    variableName: "numTeachers",
+    kind: "single-select" as const,
+    required: true,
+    options: [{ value: "10_to_24", label: "10-24 teachers" }],
+  },
+];
 
 describe("saveOrgInformation (e2e)", () => {
   let client: ReturnType<typeof getClient>;
@@ -104,10 +151,98 @@ describe("saveOrgInformation (e2e)", () => {
     });
   });
 
-  it("merges site responses onto districts/{orgId}/siteInformation/response", async () => {
+  it("rejects when the form version does not exist", async () => {
     await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
     await seedSuperAdminClaims(SUPER_ADMIN_UID);
     await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+
+    await expect(saveOrgInformation(validSiteDraft())).rejects.toMatchObject({
+      code: "functions/not-found",
+    });
+  });
+
+  it("rejects unknown response keys", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", [
+      { variableName: "sampleApproach", kind: "multi-select" },
+    ]);
+
+    await expect(
+      saveOrgInformation({
+        ...validSiteDraft(),
+        responses: { notAField: "nope" },
+      })
+    ).rejects.toMatchObject({
+      code: "functions/invalid-argument",
+      details: {
+        code: "schema",
+        issues: [
+          expect.objectContaining({
+            path: "responses.notAField",
+            message: expect.any(String),
+          }),
+        ],
+      },
+    });
+  });
+
+  it("rejects responses with the wrong value type", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await expect(
+      saveOrgInformation({
+        ...validSiteDraft(),
+        responses: { sampleApproach: "other" },
+      })
+    ).rejects.toMatchObject({
+      code: "functions/invalid-argument",
+      details: {
+        code: "schema",
+        issues: [
+          expect.objectContaining({
+            path: "responses.sampleApproach",
+            message: expect.any(String),
+          }),
+        ],
+      },
+    });
+  });
+
+  it("rejects values outside the field options", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await expect(
+      saveOrgInformation({
+        ...validSiteDraft(),
+        responses: { sampleApproach: ["not-an-option"] },
+      })
+    ).rejects.toMatchObject({
+      code: "functions/invalid-argument",
+      details: {
+        code: "schema",
+        issues: [
+          expect.objectContaining({
+            path: "responses.sampleApproach",
+            message: expect.any(String),
+          }),
+        ],
+      },
+    });
+  });
+
+  it("merges site responses onto districts/{orgId}/siteInformation/version-1", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
 
     const { data } = await saveOrgInformation(validSiteDraft());
     expect(data).toEqual({
@@ -115,11 +250,11 @@ describe("saveOrgInformation (e2e)", () => {
       orgId: SITE,
       formVersion: "version-1",
       status: "draft",
-      path: `districts/${SITE}/siteInformation/response`,
+      path: `districts/${SITE}/siteInformation/version-1`,
     });
 
     const snap = await adminDb
-      .doc(`districts/${SITE}/siteInformation/response`)
+      .doc(`districts/${SITE}/siteInformation/version-1`)
       .get();
     expect(snap.data()).toEqual({
       sampleApproach: ["other"],
@@ -133,40 +268,158 @@ describe("saveOrgInformation (e2e)", () => {
       orgId: SITE,
       formVersion: "version-1",
       responses: { siteRecruitment: "email" },
-      status: "submitted",
+      status: "complete",
     });
 
     const merged = await adminDb
-      .doc(`districts/${SITE}/siteInformation/response`)
+      .doc(`districts/${SITE}/siteInformation/version-1`)
       .get();
     expect(merged.data()).toEqual({
       sampleApproach: ["other"],
       sampleApproachOther: "word of mouth",
       siteRecruitment: "email",
       formVersion: "version-1",
-      status: "submitted",
+      status: "complete",
     });
   });
 
-  it("merges school responses onto schools/{orgId}/schoolInformation/response", async () => {
+  it("rejects complete when a required field is missing", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "site",
+        orgId: SITE,
+        formVersion: "version-1",
+        responses: { sampleApproach: ["convenience"] },
+        status: "complete",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/failed-precondition",
+    });
+
+    const snap = await adminDb
+      .doc(`districts/${SITE}/siteInformation/version-1`)
+      .get();
+    expect(snap.exists).toBe(false);
+  });
+
+  it("rejects complete when Other is selected without Other text", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await expect(
+      saveOrgInformation({
+        orgType: "site",
+        orgId: SITE,
+        formVersion: "version-1",
+        responses: {
+          sampleApproach: ["other"],
+          siteRecruitment: "email",
+        },
+        status: "complete",
+      })
+    ).rejects.toMatchObject({
+      code: "functions/failed-precondition",
+    });
+  });
+
+  it("allows complete without Other text when Other is not selected", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    const { data } = await saveOrgInformation({
+      orgType: "site",
+      orgId: SITE,
+      formVersion: "version-1",
+      responses: {
+        sampleApproach: ["convenience"],
+        siteRecruitment: "email",
+      },
+      status: "complete",
+    });
+
+    expect(data.status).toBe("complete");
+  });
+
+  it("deletes Other text when Other is unselected and the field is sent as null", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await saveOrgInformation(validSiteDraft());
+    await saveOrgInformation({
+      orgType: "site",
+      orgId: SITE,
+      formVersion: "version-1",
+      responses: {
+        sampleApproach: ["convenience"],
+        sampleApproachOther: null,
+      },
+      status: "draft",
+    });
+
+    const snap = await adminDb
+      .doc(`districts/${SITE}/siteInformation/version-1`)
+      .get();
+    expect(snap.data()).toEqual({
+      sampleApproach: ["convenience"],
+      formVersion: "version-1",
+      status: "draft",
+    });
+  });
+
+  it("treats null on a never-saved field as a no-op", async () => {
+    await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
+    await seedSuperAdminClaims(SUPER_ADMIN_UID);
+    await adminDb.doc(`districts/${SITE}`).set({ name: "Site 1" });
+    await seedFormVersion("siteInformation", "version-1", siteFields);
+
+    await saveOrgInformation({
+      orgType: "site",
+      orgId: SITE,
+      formVersion: "version-1",
+      responses: { siteRecruitment: null },
+      status: "draft",
+    });
+
+    const snap = await adminDb
+      .doc(`districts/${SITE}/siteInformation/version-1`)
+      .get();
+    expect(snap.data()).toEqual({
+      formVersion: "version-1",
+      status: "draft",
+    });
+  });
+
+  it("merges school responses onto schools/{orgId}/schoolInformation/version-2", async () => {
     await signInAs(client, SUPER_ADMIN_UID, { super_admin: true });
     await seedSuperAdminClaims(SUPER_ADMIN_UID);
     await adminDb.doc(`schools/${SCHOOL}`).set({ name: "School 1" });
+    await seedFormVersion("schoolInformation", "version-2", schoolFields);
 
     const { data } = await saveOrgInformation({
       orgType: "school",
       orgId: SCHOOL,
       formVersion: "version-2",
-      responses: { numTeachers: "12" },
+      responses: { numTeachers: "10_to_24" },
       status: "draft",
     });
 
-    expect(data.path).toBe(`schools/${SCHOOL}/schoolInformation/response`);
+    expect(data.path).toBe(`schools/${SCHOOL}/schoolInformation/version-2`);
     const snap = await adminDb
-      .doc(`schools/${SCHOOL}/schoolInformation/response`)
+      .doc(`schools/${SCHOOL}/schoolInformation/version-2`)
       .get();
     expect(snap.data()).toEqual({
-      numTeachers: "12",
+      numTeachers: "10_to_24",
       formVersion: "version-2",
       status: "draft",
     });

--- a/emulator_scripts/seed-form-definitions.js
+++ b/emulator_scripts/seed-form-definitions.js
@@ -1,0 +1,30 @@
+/**
+ * Seed only org-information form definitions (useful after editing *.seed.json).
+ *
+ * Usage (from levante-firebase-functions, with emulator running):
+ *   npm run emulator:seed:forms
+ */
+const admin = require("firebase-admin");
+const { getSeedConfig } = require("./config");
+const { createFormDefinitions } = require("./seeders/formDefinitions");
+
+const { projectId, isEmulator } = getSeedConfig();
+
+if (isEmulator) {
+  process.env.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8180";
+  process.env.FIREBASE_AUTH_EMULATOR_HOST = "127.0.0.1:9199";
+}
+
+const adminApp = admin.initializeApp({ projectId }, "admin-form-definition-seeder");
+
+createFormDefinitions(adminApp)
+  .then((created) => {
+    console.log(`Seeded ${created.length} form definition(s).`);
+    created.forEach(({ formId, versionIds }) => {
+      console.log(`- formDefinitions/${formId} (${versionIds.join(", ")})`);
+    });
+  })
+  .catch((error) => {
+    console.error("Form definition seeding failed:", error.message);
+    process.exitCode = 1;
+  });

--- a/emulator_scripts/seed-form-definitions.js
+++ b/emulator_scripts/seed-form-definitions.js
@@ -11,8 +11,8 @@ const { createFormDefinitions } = require("./seeders/formDefinitions");
 const { projectId, isEmulator } = getSeedConfig();
 
 if (isEmulator) {
-  process.env.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8180";
-  process.env.FIREBASE_AUTH_EMULATOR_HOST = "127.0.0.1:9199";
+  process.env.FIRESTORE_EMULATOR_HOST ||= "127.0.0.1:8180";
+  process.env.FIREBASE_AUTH_EMULATOR_HOST ||= "127.0.0.1:9199";
 }
 
 const adminApp = admin.initializeApp({ projectId }, "admin-form-definition-seeder");

--- a/emulator_scripts/seeders/formDefinitions.js
+++ b/emulator_scripts/seeders/formDefinitions.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const admin = require('firebase-admin');
+
+const SEED_DIR = path.join(__dirname, '../seed-data/org-information-forms');
+
+const VERSION_TIMESTAMP_FIELDS = ['createdAt', 'updatedAt', 'liveFrom', 'liveUntil'];
+
+function toFirestoreTimestamp(value) {
+  if (value == null) {
+    return null;
+  }
+  return admin.firestore.Timestamp.fromDate(new Date(value));
+}
+
+function prepareVersionDocument(version) {
+  const prepared = { ...version };
+
+  for (const field of VERSION_TIMESTAMP_FIELDS) {
+    if (field in prepared) {
+      prepared[field] = toFirestoreTimestamp(prepared[field]);
+    }
+  }
+
+  return prepared;
+}
+
+function loadSeedFiles() {
+  return fs
+    .readdirSync(SEED_DIR)
+    .filter((filename) => filename.endsWith('.seed.json'))
+    .sort()
+    .map((filename) => {
+      const filePath = path.join(SEED_DIR, filename);
+      const seed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      return { filename, filePath, seed };
+    });
+}
+
+/**
+ * Seeds org-information form definitions from emulator_scripts/seed-data/org-information-forms/*.seed.json
+ * into Firestore at formDefinitions/{formId} and formDefinitions/{formId}/versions/{versionId}.
+ *
+ * @param {admin.app.App} adminApp
+ * @returns {Promise<Array<{ formId: string, versionIds: string[] }>>}
+ */
+async function createFormDefinitions(adminApp) {
+  const db = adminApp.firestore();
+  const seedFiles = loadSeedFiles();
+  const created = [];
+
+  if (seedFiles.length === 0) {
+    console.log('  ⚪ No *.seed.json files found in seed-data/org-information-forms');
+    return created;
+  }
+
+  for (const { filename, seed } of seedFiles) {
+    const { collection, documentId, definition, versions } = seed;
+
+    if (collection !== 'formDefinitions' || !documentId || !definition || !versions) {
+      throw new Error(
+        `${filename} must include collection, documentId, definition, and versions`,
+      );
+    }
+
+    const formRef = db.collection('formDefinitions').doc(documentId);
+    await formRef.set(definition);
+
+    const versionIds = [];
+    for (const [versionId, version] of Object.entries(versions)) {
+      await formRef.collection('versions').doc(versionId).set(prepareVersionDocument(version));
+      versionIds.push(versionId);
+    }
+
+    created.push({ formId: documentId, versionIds });
+    console.log(
+      `  ✓ formDefinitions/${documentId} (${versionIds.length} version(s), ${versions[versionIds[0]]?.sectionInfo?.length ?? 0} sections, ${versions[versionIds[0]]?.fullFields?.length ?? 0} fields)`,
+    );
+  }
+
+  return created;
+}
+
+module.exports = { createFormDefinitions };

--- a/emulator_scripts/start-seeded-dashboard.js
+++ b/emulator_scripts/start-seeded-dashboard.js
@@ -9,6 +9,7 @@ const appDir = process.env.E2E_APP_DIR
   : path.resolve(__dirname, "..", "..", "levante-dashboard");
 const bootstrapScript = path.resolve(__dirname, "bootstrap-ui-seed.js");
 const seedScript = path.resolve(__dirname, "seed-emulator-functions.js");
+const formSeedScript = path.resolve(__dirname, "seed-form-definitions.js");
 const firebaseBin =
   process.env.FIREBASE_BIN ||
   path.resolve(rootDir, "node_modules", ".bin", "firebase");
@@ -205,6 +206,12 @@ async function main() {
     "Seeding visible emulator dashboard data through Firebase Functions..."
   );
   runChecked("node", [seedScript], {
+    cwd: rootDir,
+    env: seedEnv,
+  });
+
+  console.log("Seeding org-information form definitions...");
+  runChecked("node", [formSeedScript], {
     cwd: rootDir,
     env: seedEnv,
   });

--- a/functions/levante-admin/firestore.indexes.json
+++ b/functions/levante-admin/firestore.indexes.json
@@ -937,6 +937,25 @@
       "density": "SPARSE_ALL"
     },
     {
+      "collectionGroup": "versions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "registered",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "versionNumber",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
       "collectionGroup": "variants",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/levante-admin/package.json
+++ b/functions/levante-admin/package.json
@@ -29,7 +29,7 @@
     "@date-fns/tz": "^1.5.0",
     "@firebase/logger": "^0.4.4",
     "@google-cloud/secret-manager": "^4.2.2",
-    "@levante-framework/levante-zod": "^1.2.4",
+    "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/load-form-definitions-schemas",
     "@levante-framework/permissions-core": "^1.2.1",
     "axios": "^1.4.0",
     "axios-oauth-1.0a": "^0.3.6",

--- a/functions/levante-admin/src/firestore-schema.ts
+++ b/functions/levante-admin/src/firestore-schema.ts
@@ -178,6 +178,8 @@ export interface SiteInformation {
    * (`formDefinitions/siteInformation/versions/{versionId}`).
    */
   formVersion: string;
+  /** `draft` for page/leave saves; `submitted` when the form is finished. */
+  status: "draft" | "submitted";
   sampleApproach: string[];
   /** Only populated when `sampleApproach` includes `"other"`. */
   sampleApproachOther?: string;
@@ -220,6 +222,8 @@ export interface SchoolInformation {
    * (`formDefinitions/schoolInformation/versions/{versionId}`).
    */
   formVersion: string;
+  /** `draft` for page/leave saves; `submitted` when the form is finished. */
+  status: "draft" | "submitted";
   numStudents: string;
   studentAgeYoungest: number;
   studentAgeOldest: number;

--- a/functions/levante-admin/src/firestore-schema.ts
+++ b/functions/levante-admin/src/firestore-schema.ts
@@ -165,54 +165,55 @@ export interface School {
 
 // --- Org information forms (`formDefinitions` collection and response subcollections) ---
 
-/**
- * Document in the `siteInformation` subcollection of `districts`.
- * Optional subcollection: a district document may or may not have siteInformation.
- * Allowed values for select fields are sourced from the runtime form definition,
- * so they are typed as strings here rather than hardcoded literal unions.
- */
-export interface SiteInformation {
+export interface SiteInformationCore {
   siteId: string;
   /**
    * Document ID of the form definition version this response was collected against
    * (`formDefinitions/siteInformation/versions/{versionId}`).
    */
   formVersion: string;
-  /** `draft` for page/leave saves; `submitted` when the form is finished. */
-  status: "draft" | "submitted";
-  sampleApproach: string[];
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  /** `draft` for page/leave saves; `complete` when the form is finished. */
+  status: "draft" | "complete";
+}
+
+export interface SiteInformationAnswers {
+  sampleApproach?: string[];
   /** Only populated when `sampleApproach` includes `"other"`. */
   sampleApproachOther?: string;
-  siteRecruitment: string;
-  adminApproach: string[];
+  siteRecruitment?: string;
+  adminApproach?: string[];
   /** Only populated when `adminApproach` includes `"other"`. */
   adminApproachOther?: string;
-  testConditions: string;
-  equipmentType: string[];
-  equipmentDevices: string;
-  siteGeoArea: string;
-  siteGeoType: string;
-  sitePopulationSize: string;
-  siteRaceEthnicity: string;
-  siteSES: string;
-  siteLifestyle: string;
-  siteTech: string;
-  siteLanguages: string;
-  siteSubsistence: string[];
-  schoolingAgeStart: number;
-  schoolingAgeEnd: number;
-  schoolingProgression: string;
-  schoolingTeacherQuals: string;
+  testConditions?: string;
+  equipmentType?: string[];
+  equipmentDevices?: string;
+  siteGeoArea?: string;
+  siteGeoType?: string;
+  sitePopulationSize?: string;
+  siteRaceEthnicity?: string;
+  siteSES?: string;
+  siteLifestyle?: string;
+  siteTech?: string;
+  siteLanguages?: string;
+  siteSubsistence?: string[];
+  schoolingAgeStart?: number;
+  schoolingAgeEnd?: number;
+  schoolingProgression?: string;
+  schoolingTeacherQuals?: string;
   anythingElse?: string;
 }
 
 /**
- * Document in the `schoolInformation` subcollection of `schools`.
- * Optional subcollection: a school document may or may not have schoolInformation.
+ * Document in the `siteInformation` subcollection of `districts`.
+ * Optional subcollection: a district document may or may not have siteInformation.
  * Allowed values for select fields are sourced from the runtime form definition,
  * so they are typed as strings here rather than hardcoded literal unions.
  */
-export interface SchoolInformation {
+export type SiteInformation = SiteInformationCore & SiteInformationAnswers;
+
+export interface SchoolInformationCore {
   siteId: string;
   siteName: string;
   schoolId: string;
@@ -222,24 +223,37 @@ export interface SchoolInformation {
    * (`formDefinitions/schoolInformation/versions/{versionId}`).
    */
   formVersion: string;
-  /** `draft` for page/leave saves; `submitted` when the form is finished. */
-  status: "draft" | "submitted";
-  numStudents: string;
-  studentAgeYoungest: number;
-  studentAgeOldest: number;
-  numTeachers: string;
-  studentsPerTeacher: number;
-  avgClassSize: string;
-  schoolFunding: string;
-  schoolReligious: string;
-  schoolTuition: string;
-  schoolSelectiveness: string[];
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  /** `draft` for page/leave saves; `complete` when the form is finished. */
+  status: "draft" | "complete";
+}
+
+export interface SchoolInformationAnswers {
+  numStudents?: string;
+  studentAgeYoungest?: number;
+  studentAgeOldest?: number;
+  numTeachers?: string;
+  studentsPerTeacher?: number;
+  avgClassSize?: string;
+  schoolFunding?: string;
+  schoolReligious?: string;
+  schoolTuition?: string;
+  schoolSelectiveness?: string[];
   /** Only populated when `schoolSelectiveness` includes `"other"`. */
   schoolSelectivenessOther?: string;
-  instructionLanguages: string;
-  schoolDayLength: number;
-  teacherQuals: string;
+  instructionLanguages?: string;
+  schoolDayLength?: number;
+  teacherQuals?: string;
 }
+
+/**
+ * Document in the `schoolInformation` subcollection of `schools`.
+ * Optional subcollection: a school document may or may not have schoolInformation.
+ * Allowed values for select fields are sourced from the runtime form definition,
+ * so they are typed as strings here rather than hardcoded literal unions.
+ */
+export type SchoolInformation = SchoolInformationCore & SchoolInformationAnswers;
 
 /** Response field keys shared across org-information forms (site and school). */
 export type InformationFieldKey =

--- a/functions/levante-admin/src/forms/load-form-definitions.ts
+++ b/functions/levante-admin/src/forms/load-form-definitions.ts
@@ -15,6 +15,11 @@ function formIdFromOrgType(orgType: OrgType): string {
   return "schoolInformation";
 }
 
+function orgCollectionFromOrgType(orgType: OrgType): "districts" | "schools" {
+  if (orgType === "site") return "districts";
+  return "schools";
+}
+
 /**
  * Reads a form definition and its registered (live) version from Firestore.
  *
@@ -101,6 +106,19 @@ export const loadFormDefinitions = onCall(
     const { orgType, orgId } = parsed.data;
 
     try {
+      const orgCollection = orgCollectionFromOrgType(orgType);
+      const orgSnap = await getFirestore()
+        .collection(orgCollection)
+        .doc(orgId)
+        .get();
+
+      if (!orgSnap.exists) {
+        throw new HttpsError(
+          "not-found",
+          `${orgCollection} document "${orgId}" was not found.`
+        );
+      }
+
       const formId = formIdFromOrgType(orgType);
       const definition = await loadFormDefinition(formId);
 

--- a/functions/levante-admin/src/forms/load-form-definitions.ts
+++ b/functions/levante-admin/src/forms/load-form-definitions.ts
@@ -1,0 +1,146 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+type OrgType = "site" | "school";
+
+interface FormSectionInfo {
+  sectionId: string;
+  title: string;
+  description: string;
+}
+
+interface InformationFormField {
+  itemId: string;
+  variableName: string;
+  kind: "text" | "number" | "single-select" | "multi-select";
+  required: boolean;
+  sectionId: string;
+  questionText: string;
+  options?: { value: string; label: string }[];
+  displayLogic?: { field: string; includes: string };
+  infoExample?: string;
+  notes?: string;
+}
+
+export interface LoadFormDefinitionsResult {
+  formId: string;
+  versionId: string;
+  versionNumber: number;
+  formDescription: string;
+  fieldsDescription: Record<string, string>;
+  generalPrompt: string;
+  sectionInfo: FormSectionInfo[];
+  fullFields: InformationFormField[];
+  orgType: OrgType;
+  orgId: string;
+  savedResponses: unknown[];
+}
+
+function formIdFromOrgType(orgType: OrgType): string {
+  if (orgType === "site") return "siteInformation";
+  return "schoolInformation";
+}
+
+/**
+ * Reads a form definition and its registered (live) version from Firestore.
+ *
+ * Resolves the version in this order:
+ *  1. `formDefinitions/{formId}.currentVersionId`, if that version is `registered`.
+ *  2. otherwise the highest `versionNumber` among `registered` versions.
+ */
+async function loadFormDefinition(formId: string) {
+  const db = getFirestore();
+
+  const formRef = db.collection("formDefinitions").doc(formId);
+  const formSnap = await formRef.get();
+
+  if (!formSnap.exists) {
+    throw new HttpsError(
+      "not-found",
+      `Form definition "${formId}" was not found.`
+    );
+  }
+
+  const form = formSnap.data() as {
+    currentVersionId?: string;
+    formDescription?: string;
+    fieldsDescription?: Record<string, string>;
+  };
+
+  const versionsRef = formRef.collection("versions");
+  let versionSnap = form.currentVersionId
+    ? await versionsRef.doc(form.currentVersionId).get()
+    : null;
+
+  if (!versionSnap?.exists || versionSnap.get("registered") !== true) {
+    const registeredSnap = await versionsRef
+      .where("registered", "==", true)
+      .orderBy("versionNumber", "desc")
+      .limit(1)
+      .get();
+
+    if (registeredSnap.empty) {
+      throw new HttpsError(
+        "failed-precondition",
+        `Form "${formId}" has no registered version.`
+      );
+    }
+
+    versionSnap = registeredSnap.docs[0];
+  }
+
+  const version = versionSnap.data() as {
+    versionNumber?: number;
+    generalPrompt?: string;
+    sectionInfo?: FormSectionInfo[];
+    fullFields?: InformationFormField[];
+  };
+
+  return {
+    formId,
+    versionId: versionSnap.id,
+    versionNumber: version.versionNumber ?? 0,
+    formDescription: form.formDescription ?? "",
+    fieldsDescription: form.fieldsDescription ?? {},
+    generalPrompt: version.generalPrompt ?? "",
+    sectionInfo: version.sectionInfo ?? [],
+    fullFields: version.fullFields ?? [],
+  };
+}
+
+export const loadFormDefinitions = onCall(
+  async (request): Promise<LoadFormDefinitionsResult> => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "User must be authenticated");
+    }
+
+    const { orgType, orgId } = request.data ?? {};
+
+    if (orgType !== "site" && orgType !== "school") {
+      throw new HttpsError(
+        "invalid-argument",
+        "orgType must be site or school"
+      );
+    }
+    if (!orgId || typeof orgId !== "string") {
+      throw new HttpsError("invalid-argument", "orgId is required");
+    }
+
+    try {
+      const formId = formIdFromOrgType(orgType);
+      const definition = await loadFormDefinition(formId);
+
+      return {
+        ...definition,
+        orgType,
+        orgId,
+        savedResponses: [],
+      };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      logger.error("loadFormDefinitions failed", { error, orgType, orgId });
+      throw new HttpsError("internal", "Failed to load form definitions.");
+    }
+  }
+);

--- a/functions/levante-admin/src/forms/load-form-definitions.ts
+++ b/functions/levante-admin/src/forms/load-form-definitions.ts
@@ -7,18 +7,7 @@ import {
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { HttpsError, onCall } from "firebase-functions/v2/https";
-
-type OrgType = "site" | "school";
-
-function formIdFromOrgType(orgType: OrgType): string {
-  if (orgType === "site") return "siteInformation";
-  return "schoolInformation";
-}
-
-function orgCollectionFromOrgType(orgType: OrgType): "districts" | "schools" {
-  if (orgType === "site") return "districts";
-  return "schools";
-}
+import { formIdFromOrgType, orgCollectionFromOrgType } from "./org-paths.js";
 
 /**
  * Reads a form definition and its registered (live) version from Firestore.

--- a/functions/levante-admin/src/forms/load-form-definitions.ts
+++ b/functions/levante-admin/src/forms/load-form-definitions.ts
@@ -1,41 +1,14 @@
+import {
+  type FormSectionInfo,
+  type InformationFormField,
+  LoadFormDefinitionsParamsSchema,
+  type LoadFormDefinitionsResult,
+} from "@levante-framework/levante-zod";
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { HttpsError, onCall } from "firebase-functions/v2/https";
 
 type OrgType = "site" | "school";
-
-interface FormSectionInfo {
-  sectionId: string;
-  title: string;
-  description: string;
-}
-
-interface InformationFormField {
-  itemId: string;
-  variableName: string;
-  kind: "text" | "number" | "single-select" | "multi-select";
-  required: boolean;
-  sectionId: string;
-  questionText: string;
-  options?: { value: string; label: string }[];
-  displayLogic?: { field: string; includes: string };
-  infoExample?: string;
-  notes?: string;
-}
-
-export interface LoadFormDefinitionsResult {
-  formId: string;
-  versionId: string;
-  versionNumber: number;
-  formDescription: string;
-  fieldsDescription: Record<string, string>;
-  generalPrompt: string;
-  sectionInfo: FormSectionInfo[];
-  fullFields: InformationFormField[];
-  orgType: OrgType;
-  orgId: string;
-  savedResponses: unknown[];
-}
 
 function formIdFromOrgType(orgType: OrgType): string {
   if (orgType === "site") return "siteInformation";
@@ -115,17 +88,17 @@ export const loadFormDefinitions = onCall(
       throw new HttpsError("unauthenticated", "User must be authenticated");
     }
 
-    const { orgType, orgId } = request.data ?? {};
-
-    if (orgType !== "site" && orgType !== "school") {
-      throw new HttpsError(
-        "invalid-argument",
-        "orgType must be site or school"
-      );
+    const parsed = LoadFormDefinitionsParamsSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError("invalid-argument", "Invalid input", {
+        code: "schema",
+        issues: parsed.error.issues.map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+        })),
+      });
     }
-    if (!orgId || typeof orgId !== "string") {
-      throw new HttpsError("invalid-argument", "orgId is required");
-    }
+    const { orgType, orgId } = parsed.data;
 
     try {
       const formId = formIdFromOrgType(orgType);

--- a/functions/levante-admin/src/forms/org-paths.ts
+++ b/functions/levante-admin/src/forms/org-paths.ts
@@ -1,0 +1,15 @@
+export type OrgType = "site" | "school";
+
+export function orgCollectionFromOrgType(
+  orgType: OrgType
+): "districts" | "schools" {
+  if (orgType === "site") return "districts";
+  return "schools";
+}
+
+export function formIdFromOrgType(
+  orgType: OrgType
+): "siteInformation" | "schoolInformation" {
+  if (orgType === "site") return "siteInformation";
+  return "schoolInformation";
+}

--- a/functions/levante-admin/src/forms/save-org-information.ts
+++ b/functions/levante-admin/src/forms/save-org-information.ts
@@ -2,9 +2,12 @@ import {
   SaveOrgInformationParamsSchema,
   type SaveOrgInformationResult,
 } from "@levante-framework/levante-zod";
-import { getFirestore } from "firebase-admin/firestore";
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { HttpsError, onCall } from "firebase-functions/v2/https";
+import type { FormDefinitionVersion } from "../firestore-schema.js";
+import { validateResponseShape } from "./validate-response-shape.js";
+import { findMissingRequiredFields } from "./validate-complete-answers.js";
 
 type OrgType = "site" | "school";
 
@@ -18,6 +21,16 @@ function informationSubcollectionFromOrgType(
 ): "siteInformation" | "schoolInformation" {
   if (orgType === "site") return "siteInformation";
   return "schoolInformation";
+}
+
+function responsesForWrite(
+  responses: Record<string, unknown>
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(responses)) {
+    payload[key] = value === null ? FieldValue.delete() : value;
+  }
+  return payload;
 }
 
 export const saveOrgInformation = onCall(
@@ -66,13 +79,59 @@ export const saveOrgInformation = onCall(
         );
       }
 
-      const subcollection = informationSubcollectionFromOrgType(orgType);
-      const responseRef = orgRef.collection(subcollection).doc("response");
-      const path = `${orgCollection}/${orgId}/${subcollection}/response`;
+      const formId = informationSubcollectionFromOrgType(orgType);
+      const versionSnap = await db
+        .collection("formDefinitions")
+        .doc(formId)
+        .collection("versions")
+        .doc(formVersion)
+        .get();
+
+      if (!versionSnap.exists) {
+        throw new HttpsError(
+          "not-found",
+          `Form version "${formVersion}" was not found.`
+        );
+      }
+
+      const version = versionSnap.data() as FormDefinitionVersion;
+      const issues = validateResponseShape(responses, version.fullFields);
+
+      if (issues.length > 0) {
+        throw new HttpsError("invalid-argument", "Invalid input", {
+          code: "schema",
+          issues,
+        });
+      }
+
+      const responseRef = orgRef.collection(formId).doc(formVersion);
+      const path = `${orgCollection}/${orgId}/${formId}/${formVersion}`;
+
+      if (status === "complete") {
+        const existingSnap = await responseRef.get();
+        const merged: Record<string, unknown> = {
+          ...(existingSnap.data() ?? {}),
+          ...responses,
+        };
+        for (const [key, value] of Object.entries(responses)) {
+          if (value === null) delete merged[key];
+        }
+        const missing = findMissingRequiredFields(
+          merged,
+          version.fullFields
+        );
+
+        if (missing.length > 0) {
+          throw new HttpsError(
+            "failed-precondition",
+            `Required fields are missing: ${missing.join(", ")}`
+          );
+        }
+      }
 
       await responseRef.set(
         {
-          ...responses,
+          ...responsesForWrite(responses),
           formVersion,
           status,
         },

--- a/functions/levante-admin/src/forms/save-org-information.ts
+++ b/functions/levante-admin/src/forms/save-org-information.ts
@@ -1,0 +1,100 @@
+import {
+  SaveOrgInformationParamsSchema,
+  type SaveOrgInformationResult,
+} from "@levante-framework/levante-zod";
+import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+type OrgType = "site" | "school";
+
+function orgCollectionFromOrgType(orgType: OrgType): "districts" | "schools" {
+  if (orgType === "site") return "districts";
+  return "schools";
+}
+
+function informationSubcollectionFromOrgType(
+  orgType: OrgType
+): "siteInformation" | "schoolInformation" {
+  if (orgType === "site") return "siteInformation";
+  return "schoolInformation";
+}
+
+export const saveOrgInformation = onCall(
+  async (request): Promise<SaveOrgInformationResult> => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "User must be authenticated");
+    }
+
+    const parsed = SaveOrgInformationParamsSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError("invalid-argument", "Invalid input", {
+        code: "schema",
+        issues: parsed.error.issues.map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+        })),
+      });
+    }
+
+    const { orgType, orgId, formVersion, responses, status } = parsed.data;
+    const requestingUid = request.auth.uid;
+    const db = getFirestore();
+
+    try {
+      const userClaimsSnap = await db
+        .collection("userClaims")
+        .doc(requestingUid)
+        .get();
+      const isSuperAdmin = userClaimsSnap.data()?.claims?.super_admin === true;
+
+      if (!isSuperAdmin) {
+        throw new HttpsError(
+          "permission-denied",
+          "You must be a super admin to save org information."
+        );
+      }
+
+      const orgCollection = orgCollectionFromOrgType(orgType);
+      const orgRef = db.collection(orgCollection).doc(orgId);
+      const orgSnap = await orgRef.get();
+
+      if (!orgSnap.exists) {
+        throw new HttpsError(
+          "not-found",
+          `${orgCollection} document "${orgId}" was not found.`
+        );
+      }
+
+      const subcollection = informationSubcollectionFromOrgType(orgType);
+      const responseRef = orgRef.collection(subcollection).doc("response");
+      const path = `${orgCollection}/${orgId}/${subcollection}/response`;
+
+      await responseRef.set(
+        {
+          ...responses,
+          formVersion,
+          status,
+        },
+        { merge: true }
+      );
+
+      return {
+        orgType,
+        orgId,
+        formVersion,
+        status,
+        path,
+      };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      logger.error("saveOrgInformation failed", {
+        error,
+        orgType,
+        orgId,
+        requestingUid,
+      });
+      throw new HttpsError("internal", "Failed to save org information.");
+    }
+  }
+);

--- a/functions/levante-admin/src/forms/save-org-information.ts
+++ b/functions/levante-admin/src/forms/save-org-information.ts
@@ -54,6 +54,14 @@ async function coreFieldsFromOrg(
     );
   }
 
+  const schoolName = orgSnap.get("name") as string | undefined;
+  if (!schoolName) {
+    throw new HttpsError(
+      "not-found",
+      `name was not found on schools document "${orgId}".`
+    );
+  }
+
   const districtSnap = await db.collection("districts").doc(districtId).get();
   if (!districtSnap.exists) {
     throw new HttpsError(
@@ -62,11 +70,19 @@ async function coreFieldsFromOrg(
     );
   }
 
+  const siteName = districtSnap.get("name") as string | undefined;
+  if (!siteName) {
+    throw new HttpsError(
+      "not-found",
+      `name was not found on districts document "${districtId}".`
+    );
+  }
+
   return {
     schoolId: orgId,
     siteId: districtId,
-    schoolPseudonym: orgSnap.get("name"),
-    siteName: districtSnap.get("name"),
+    schoolPseudonym: schoolName,
+    siteName,
   };
 }
 

--- a/functions/levante-admin/src/forms/save-org-information.ts
+++ b/functions/levante-admin/src/forms/save-org-information.ts
@@ -7,26 +7,18 @@ import {
   getFirestore,
   type DocumentSnapshot,
   type Firestore,
+  type Transaction,
 } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { HttpsError, onCall } from "firebase-functions/v2/https";
 import type { FormDefinitionVersion } from "../firestore-schema.js";
+import {
+  formIdFromOrgType,
+  orgCollectionFromOrgType,
+  type OrgType,
+} from "./org-paths.js";
 import { validateResponseShape } from "./validate-response-shape.js";
 import { findMissingRequiredFields } from "./validate-complete-answers.js";
-
-type OrgType = "site" | "school";
-
-function orgCollectionFromOrgType(orgType: OrgType): "districts" | "schools" {
-  if (orgType === "site") return "districts";
-  return "schools";
-}
-
-function informationSubcollectionFromOrgType(
-  orgType: OrgType
-): "siteInformation" | "schoolInformation" {
-  if (orgType === "site") return "siteInformation";
-  return "schoolInformation";
-}
 
 function responsesForWrite(
   responses: Record<string, unknown>
@@ -38,23 +30,31 @@ function responsesForWrite(
   return payload;
 }
 
+function requiredString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
 async function coreFieldsFromOrg(
   orgType: OrgType,
   orgId: string,
   orgSnap: DocumentSnapshot,
-  db: Firestore
+  db: Firestore,
+  tx: Transaction
 ): Promise<Record<string, unknown>> {
   if (orgType === "site") return { siteId: orgId };
 
-  const districtId = orgSnap.get("districtId") as string | undefined;
+  const districtId = requiredString(orgSnap.get("districtId"));
   if (!districtId) {
     throw new HttpsError(
       "not-found",
-      `districts document for school "${orgId}" was not found.`
+      `districtId was not found on schools document "${orgId}".`
     );
   }
 
-  const schoolName = orgSnap.get("name") as string | undefined;
+  const schoolName = requiredString(orgSnap.get("name"));
   if (!schoolName) {
     throw new HttpsError(
       "not-found",
@@ -62,7 +62,7 @@ async function coreFieldsFromOrg(
     );
   }
 
-  const districtSnap = await db.collection("districts").doc(districtId).get();
+  const districtSnap = await tx.get(db.collection("districts").doc(districtId));
   if (!districtSnap.exists) {
     throw new HttpsError(
       "not-found",
@@ -70,7 +70,7 @@ async function coreFieldsFromOrg(
     );
   }
 
-  const siteName = districtSnap.get("name") as string | undefined;
+  const siteName = requiredString(districtSnap.get("name"));
   if (!siteName) {
     throw new HttpsError(
       "not-found",
@@ -132,9 +132,7 @@ export const saveOrgInformation = onCall(
         );
       }
 
-      const coreFields = await coreFieldsFromOrg(orgType, orgId, orgSnap, db);
-
-      const formId = informationSubcollectionFromOrgType(orgType);
+      const formId = formIdFromOrgType(orgType);
       const versionSnap = await db
         .collection("formDefinitions")
         .doc(formId)
@@ -146,6 +144,13 @@ export const saveOrgInformation = onCall(
         throw new HttpsError(
           "not-found",
           `Form version "${formVersion}" was not found.`
+        );
+      }
+
+      if (versionSnap.get("registered") !== true) {
+        throw new HttpsError(
+          "failed-precondition",
+          `Form version "${formVersion}" is not registered.`
         );
       }
 
@@ -171,6 +176,14 @@ export const saveOrgInformation = onCall(
           savedStatus = "complete";
           return;
         }
+
+        const coreFields = await coreFieldsFromOrg(
+          orgType,
+          orgId,
+          orgSnap,
+          db,
+          tx
+        );
 
         if (status === "complete") {
           const merged: Record<string, unknown> = {

--- a/functions/levante-admin/src/forms/save-org-information.ts
+++ b/functions/levante-admin/src/forms/save-org-information.ts
@@ -2,7 +2,12 @@ import {
   SaveOrgInformationParamsSchema,
   type SaveOrgInformationResult,
 } from "@levante-framework/levante-zod";
-import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import {
+  FieldValue,
+  getFirestore,
+  type DocumentSnapshot,
+  type Firestore,
+} from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { HttpsError, onCall } from "firebase-functions/v2/https";
 import type { FormDefinitionVersion } from "../firestore-schema.js";
@@ -31,6 +36,38 @@ function responsesForWrite(
     payload[key] = value === null ? FieldValue.delete() : value;
   }
   return payload;
+}
+
+async function coreFieldsFromOrg(
+  orgType: OrgType,
+  orgId: string,
+  orgSnap: DocumentSnapshot,
+  db: Firestore
+): Promise<Record<string, unknown>> {
+  if (orgType === "site") return { siteId: orgId };
+
+  const districtId = orgSnap.get("districtId") as string | undefined;
+  if (!districtId) {
+    throw new HttpsError(
+      "not-found",
+      `districts document for school "${orgId}" was not found.`
+    );
+  }
+
+  const districtSnap = await db.collection("districts").doc(districtId).get();
+  if (!districtSnap.exists) {
+    throw new HttpsError(
+      "not-found",
+      `districts document "${districtId}" was not found.`
+    );
+  }
+
+  return {
+    schoolId: orgId,
+    siteId: districtId,
+    schoolPseudonym: orgSnap.get("name"),
+    siteName: districtSnap.get("name"),
+  };
 }
 
 export const saveOrgInformation = onCall(
@@ -79,6 +116,8 @@ export const saveOrgInformation = onCall(
         );
       }
 
+      const coreFields = await coreFieldsFromOrg(orgType, orgId, orgSnap, db);
+
       const formId = informationSubcollectionFromOrgType(orgType);
       const versionSnap = await db
         .collection("formDefinitions")
@@ -106,43 +145,53 @@ export const saveOrgInformation = onCall(
 
       const responseRef = orgRef.collection(formId).doc(formVersion);
       const path = `${orgCollection}/${orgId}/${formId}/${formVersion}`;
+      let savedStatus = status;
 
-      if (status === "complete") {
-        const existingSnap = await responseRef.get();
-        const merged: Record<string, unknown> = {
-          ...(existingSnap.data() ?? {}),
-          ...responses,
-        };
-        for (const [key, value] of Object.entries(responses)) {
-          if (value === null) delete merged[key];
+      await db.runTransaction(async (tx) => {
+        const existingSnap = await tx.get(responseRef);
+        const existing = existingSnap.data();
+
+        if (existing?.status === "complete" && status === "draft") {
+          savedStatus = "complete";
+          return;
         }
-        const missing = findMissingRequiredFields(
-          merged,
-          version.fullFields
-        );
 
-        if (missing.length > 0) {
-          throw new HttpsError(
-            "failed-precondition",
-            `Required fields are missing: ${missing.join(", ")}`
-          );
+        if (status === "complete") {
+          const merged: Record<string, unknown> = {
+            ...(existing ?? {}),
+            ...responses,
+          };
+          for (const [key, value] of Object.entries(responses)) {
+            if (value === null) delete merged[key];
+          }
+          const missing = findMissingRequiredFields(merged, version.fullFields);
+
+          if (missing.length > 0) {
+            throw new HttpsError(
+              "failed-precondition",
+              `Required fields are missing: ${missing.join(", ")}`
+            );
+          }
         }
-      }
 
-      await responseRef.set(
-        {
+        const payload: Record<string, unknown> = {
           ...responsesForWrite(responses),
+          ...coreFields,
           formVersion,
           status,
-        },
-        { merge: true }
-      );
+          updatedAt: FieldValue.serverTimestamp(),
+        };
+        if (!existingSnap.exists) {
+          payload.createdAt = FieldValue.serverTimestamp();
+        }
+        tx.set(responseRef, payload, { merge: true });
+      });
 
       return {
         orgType,
         orgId,
         formVersion,
-        status,
+        status: savedStatus,
         path,
       };
     } catch (error) {

--- a/functions/levante-admin/src/forms/validate-complete-answers.test.ts
+++ b/functions/levante-admin/src/forms/validate-complete-answers.test.ts
@@ -30,22 +30,17 @@ describe("findMissingRequiredFields", () => {
 
   it("treats omitted required keys as missing", () => {
     expect(
-      findMissingRequiredFields(
-        { sampleApproach: ["convenience"] },
-        fields
-      )
+      findMissingRequiredFields({ sampleApproach: ["convenience"] }, fields)
     ).toEqual(["siteRecruitment"]);
   });
 
-  it("treats an empty string as missing", () => {
+  it("treats empty and whitespace-only strings as missing", () => {
+    const answers = { sampleApproach: ["convenience"] };
     expect(
-      findMissingRequiredFields(
-        {
-          sampleApproach: ["convenience"],
-          siteRecruitment: "",
-        },
-        fields
-      )
+      findMissingRequiredFields({ ...answers, siteRecruitment: "" }, fields)
+    ).toEqual(["siteRecruitment"]);
+    expect(
+      findMissingRequiredFields({ ...answers, siteRecruitment: "   " }, fields)
     ).toEqual(["siteRecruitment"]);
   });
 

--- a/functions/levante-admin/src/forms/validate-complete-answers.test.ts
+++ b/functions/levante-admin/src/forms/validate-complete-answers.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CompleteFieldShape,
+  findMissingRequiredFields,
+} from "./validate-complete-answers.js";
+
+const fields: CompleteFieldShape[] = [
+  { variableName: "sampleApproach", required: true },
+  {
+    variableName: "sampleApproachOther",
+    required: true,
+    displayLogic: { field: "sampleApproach", includes: "other" },
+  },
+  { variableName: "siteRecruitment", required: true },
+  { variableName: "optionalNote", required: false },
+];
+
+describe("findMissingRequiredFields", () => {
+  it("returns no names when required answers are present", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["convenience"],
+          siteRecruitment: "email",
+        },
+        fields
+      )
+    ).toEqual([]);
+  });
+
+  it("treats omitted required keys as missing", () => {
+    expect(
+      findMissingRequiredFields(
+        { sampleApproach: ["convenience"] },
+        fields
+      )
+    ).toEqual(["siteRecruitment"]);
+  });
+
+  it("treats an empty string as missing", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["convenience"],
+          siteRecruitment: "",
+        },
+        fields
+      )
+    ).toEqual(["siteRecruitment"]);
+  });
+
+  it("treats null as missing", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["convenience"],
+          siteRecruitment: null,
+        },
+        fields
+      )
+    ).toEqual(["siteRecruitment"]);
+  });
+
+  it("treats an empty array as missing", () => {
+    expect(
+      findMissingRequiredFields(
+        { sampleApproach: [], siteRecruitment: "email" },
+        fields
+      )
+    ).toEqual(["sampleApproach"]);
+  });
+
+  it("does not treat 0 as missing", () => {
+    expect(
+      findMissingRequiredFields({ count: 0 }, [
+        { variableName: "count", required: true },
+      ])
+    ).toEqual([]);
+  });
+
+  it("requires Other text when Other is selected", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["other"],
+          siteRecruitment: "email",
+        },
+        fields
+      )
+    ).toEqual(["sampleApproachOther"]);
+  });
+
+  it("requires Other text when Other is selected and the text is null", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["other"],
+          sampleApproachOther: null,
+          siteRecruitment: "email",
+        },
+        fields
+      )
+    ).toEqual(["sampleApproachOther"]);
+  });
+
+  it("does not require Other text when Other is not selected", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["convenience"],
+          siteRecruitment: "email",
+        },
+        fields
+      )
+    ).toEqual([]);
+  });
+
+  it("does not require Other text when Other is cleared and the text is null", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["convenience"],
+          sampleApproachOther: null,
+          siteRecruitment: "email",
+        },
+        fields
+      )
+    ).toEqual([]);
+  });
+
+  it("accepts Other text when Other is selected", () => {
+    expect(
+      findMissingRequiredFields(
+        {
+          sampleApproach: ["other"],
+          sampleApproachOther: "word of mouth",
+          siteRecruitment: "email",
+        },
+        fields
+      )
+    ).toEqual([]);
+  });
+});

--- a/functions/levante-admin/src/forms/validate-complete-answers.ts
+++ b/functions/levante-admin/src/forms/validate-complete-answers.ts
@@ -1,0 +1,42 @@
+export type CompleteFieldShape = {
+  variableName: string;
+  required: boolean;
+  displayLogic?: { field: string; includes: string };
+};
+
+function isMissingValue(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (value === null) return true;
+  if (value === "") return true;
+  if (Array.isArray(value) && value.length === 0) return true;
+  return false;
+}
+
+function isDisplayLogicMet(
+  answers: Record<string, unknown>,
+  displayLogic: { field: string; includes: string }
+): boolean {
+  const parent = answers[displayLogic.field];
+  if (Array.isArray(parent)) return parent.includes(displayLogic.includes);
+  if (typeof parent === "string") return parent === displayLogic.includes;
+  return false;
+}
+
+export function findMissingRequiredFields(
+  answers: Record<string, unknown>,
+  fields: CompleteFieldShape[]
+): string[] {
+  const missing: string[] = [];
+
+  for (const field of fields) {
+    if (!field.required) continue;
+    if (field.displayLogic && !isDisplayLogicMet(answers, field.displayLogic)) {
+      continue;
+    }
+    if (isMissingValue(answers[field.variableName])) {
+      missing.push(field.variableName);
+    }
+  }
+
+  return missing;
+}

--- a/functions/levante-admin/src/forms/validate-complete-answers.ts
+++ b/functions/levante-admin/src/forms/validate-complete-answers.ts
@@ -7,7 +7,7 @@ export type CompleteFieldShape = {
 function isMissingValue(value: unknown): boolean {
   if (value === undefined) return true;
   if (value === null) return true;
-  if (value === "") return true;
+  if (typeof value === "string" && value.trim().length === 0) return true;
   if (Array.isArray(value) && value.length === 0) return true;
   return false;
 }

--- a/functions/levante-admin/src/forms/validate-response-shape.test.ts
+++ b/functions/levante-admin/src/forms/validate-response-shape.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ResponseFieldShape,
+  validateResponseShape,
+} from "./validate-response-shape.js";
+
+const fields: ResponseFieldShape[] = [
+  { variableName: "notes", kind: "text" },
+  { variableName: "schoolDayLength", kind: "number" },
+  {
+    variableName: "numTeachers",
+    kind: "single-select",
+    options: [
+      { value: "10_to_24", label: "10-24" },
+      { value: "25_plus", label: "25+" },
+    ],
+  },
+  {
+    variableName: "sampleApproach",
+    kind: "multi-select",
+    options: [
+      { value: "other", label: "Other" },
+      { value: "convenience", label: "Convenience" },
+    ],
+  },
+];
+
+describe("validateResponseShape", () => {
+  it("returns no issues for an empty payload", () => {
+    expect(validateResponseShape({}, fields)).toEqual([]);
+  });
+
+  it("allows a partial payload of valid values", () => {
+    expect(
+      validateResponseShape(
+        { notes: "ok", sampleApproach: ["other"] },
+        fields
+      )
+    ).toEqual([]);
+  });
+
+  it("rejects unknown keys", () => {
+    expect(validateResponseShape({ notAField: "nope" }, fields)).toEqual([
+      {
+        path: "responses.notAField",
+        message: 'Unknown field "notAField".',
+      },
+    ]);
+  });
+
+  it("accepts null on a known field", () => {
+    expect(validateResponseShape({ notes: null }, fields)).toEqual([]);
+  });
+
+  it("rejects null on an unknown field", () => {
+    expect(validateResponseShape({ notAField: null }, fields)).toEqual([
+      {
+        path: "responses.notAField",
+        message: 'Unknown field "notAField".',
+      },
+    ]);
+  });
+
+  it("rejects a non-string text value", () => {
+    expect(validateResponseShape({ notes: 1 }, fields)).toEqual([
+      { path: "responses.notes", message: "Expected a string." },
+    ]);
+  });
+
+  it("rejects a non-number number value", () => {
+    expect(validateResponseShape({ schoolDayLength: "12" }, fields)).toEqual([
+      { path: "responses.schoolDayLength", message: "Expected a number." },
+    ]);
+  });
+
+  it("accepts a valid number", () => {
+    expect(validateResponseShape({ schoolDayLength: 12 }, fields)).toEqual([]);
+  });
+
+  it("rejects a non-string single-select value", () => {
+    expect(validateResponseShape({ numTeachers: ["10_to_24"] }, fields)).toEqual(
+      [{ path: "responses.numTeachers", message: "Expected a string." }]
+    );
+  });
+
+  it("rejects a single-select value outside options", () => {
+    expect(validateResponseShape({ numTeachers: "12" }, fields)).toEqual([
+      {
+        path: "responses.numTeachers",
+        message: "Value is not an allowed option.",
+      },
+    ]);
+  });
+
+  it("accepts a valid single-select value", () => {
+    expect(
+      validateResponseShape({ numTeachers: "10_to_24" }, fields)
+    ).toEqual([]);
+  });
+
+  it("rejects a non-array multi-select value", () => {
+    expect(validateResponseShape({ sampleApproach: "other" }, fields)).toEqual([
+      { path: "responses.sampleApproach", message: "Expected a string array." },
+    ]);
+  });
+
+  it("rejects a multi-select array with a non-string item", () => {
+    expect(validateResponseShape({ sampleApproach: [1] }, fields)).toEqual([
+      { path: "responses.sampleApproach", message: "Expected a string array." },
+    ]);
+  });
+
+  it("rejects a multi-select value outside options", () => {
+    expect(
+      validateResponseShape({ sampleApproach: ["not-an-option"] }, fields)
+    ).toEqual([
+      {
+        path: "responses.sampleApproach",
+        message: "Value is not an allowed option.",
+      },
+    ]);
+  });
+
+  it("accepts a valid multi-select value", () => {
+    expect(
+      validateResponseShape(
+        { sampleApproach: ["other", "convenience"] },
+        fields
+      )
+    ).toEqual([]);
+  });
+
+  it("collects multiple issues", () => {
+    expect(
+      validateResponseShape(
+        { notes: 1, notAField: true, numTeachers: "12" },
+        fields
+      )
+    ).toEqual([
+      { path: "responses.notes", message: "Expected a string." },
+      {
+        path: "responses.notAField",
+        message: 'Unknown field "notAField".',
+      },
+      {
+        path: "responses.numTeachers",
+        message: "Value is not an allowed option.",
+      },
+    ]);
+  });
+});

--- a/functions/levante-admin/src/forms/validate-response-shape.ts
+++ b/functions/levante-admin/src/forms/validate-response-shape.ts
@@ -1,0 +1,79 @@
+export type ResponseFieldShape = {
+  variableName: string;
+  kind: "text" | "number" | "single-select" | "multi-select";
+  options?: { value: string; label: string }[];
+};
+
+export type ResponseShapeIssue = {
+  path: string;
+  message: string;
+};
+
+function optionValues(field: ResponseFieldShape): Set<string> {
+  return new Set((field.options ?? []).map((option) => option.value));
+}
+
+export function validateResponseShape(
+  responses: Record<string, unknown>,
+  fields: ResponseFieldShape[]
+): ResponseShapeIssue[] {
+  const fieldsByName = new Map(
+    fields.map((field) => [field.variableName, field])
+  );
+  const issues: ResponseShapeIssue[] = [];
+
+  for (const [key, value] of Object.entries(responses)) {
+    const path = `responses.${key}`;
+    const field = fieldsByName.get(key);
+
+    if (!field) {
+      issues.push({
+        path,
+        message: `Unknown field "${key}".`,
+      });
+      continue;
+    }
+
+    if (value === null) continue;
+
+    if (field.kind === "text") {
+      if (typeof value !== "string") {
+        issues.push({ path, message: "Expected a string." });
+      }
+      continue;
+    }
+
+    if (field.kind === "number") {
+      if (typeof value !== "number") {
+        issues.push({ path, message: "Expected a number." });
+      }
+      continue;
+    }
+
+    const allowed = optionValues(field);
+
+    if (field.kind === "single-select") {
+      if (typeof value !== "string") {
+        issues.push({ path, message: "Expected a string." });
+        continue;
+      }
+      if (!allowed.has(value)) {
+        issues.push({ path, message: "Value is not an allowed option." });
+      }
+      continue;
+    }
+
+    if (
+      !Array.isArray(value) ||
+      value.some((item) => typeof item !== "string")
+    ) {
+      issues.push({ path, message: "Expected a string array." });
+      continue;
+    }
+    if (value.some((item) => !allowed.has(item))) {
+      issues.push({ path, message: "Value is not an allowed option." });
+    }
+  }
+
+  return issues;
+}

--- a/functions/levante-admin/src/index.ts
+++ b/functions/levante-admin/src/index.ts
@@ -994,3 +994,4 @@ export const syncOnRunDocUpdate = onDocumentWritten(
 export { getSiteOverview } from "./sites/get-site-overview.js";
 export { getSyncStatus } from "./sites/get-sync-status.js";
 export { createUsers, syncCreatedUsersTask } from "./users/create-users.js";
+export { loadFormDefinitions } from "./forms/load-form-definitions.js";

--- a/functions/levante-admin/src/index.ts
+++ b/functions/levante-admin/src/index.ts
@@ -995,3 +995,4 @@ export { getSiteOverview } from "./sites/get-site-overview.js";
 export { getSyncStatus } from "./sites/get-sync-status.js";
 export { createUsers, syncCreatedUsersTask } from "./users/create-users.js";
 export { loadFormDefinitions } from "./forms/load-form-definitions.js";
+export { saveOrgInformation } from "./forms/save-org-information.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,6 @@
         "node": "22"
       }
     },
-    "common": {
-      "extraneous": true
-    },
     "functions/levante-admin": {
       "name": "@levante-firebase-functions/levante-admin",
       "version": "2.3.0",
@@ -43,7 +40,7 @@
         "@date-fns/tz": "^1.5.0",
         "@firebase/logger": "^0.4.4",
         "@google-cloud/secret-manager": "^4.2.2",
-        "@levante-framework/levante-zod": "^1.2.4",
+        "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/load-form-definitions-schemas",
         "@levante-framework/permissions-core": "^1.2.1",
         "axios": "^1.4.0",
         "axios-oauth-1.0a": "^0.3.6",
@@ -477,61 +474,6 @@
         "node": ">=14.17"
       }
     },
-    "functions/levante-assessment": {
-      "name": "@levante-firebase-functions/levante-assessment",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for LEVANTE",
-      "dependencies": {
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1",
-        "lodash": "^4.17.21"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "firebase-tools-with-isolate": "^13.11.2",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "functions/local": {
-      "name": "@levante-firebase-functions/local",
-      "version": "1.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@faker-js/faker": "^8.3.1",
-        "axios": "^1.5.0",
-        "cli-progress": "^3.12.0",
-        "dot-object": "^2.1.4",
-        "firebase-admin": "^12.5.0",
-        "lodash": "^4.17.21",
-        "papaparse": "^5.4.1",
-        "prompt-confirm": "^2.0.4",
-        "queue": "^7.0.0",
-        "typescript": "^5.1.6",
-        "yargs": "^17.7.2"
-      },
-      "devDependencies": {
-        "@types/dot-object": "^2.1.3",
-        "@types/node": "^20.6.0",
-        "@types/papaparse": "^5.3.8",
-        "@types/yargs": "^17.0.32",
-        "@typescript-eslint/eslint-plugin": "^5.12.0",
-        "@typescript-eslint/parser": "^5.12.0",
-        "eslint": "^8.9.0",
-        "eslint-config-google": "^0.14.0",
-        "eslint-plugin-import": "^2.25.4",
-        "prettier": "^2.8.1",
-        "tsx": "^4.1.3"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -730,8 +672,7 @@
       "version": "0.3.16",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
       "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-tools": {
       "version": "0.2.21",
@@ -1253,7 +1194,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.0.tgz",
       "integrity": "sha512-Vj3MST245nq+V5UmmfEkB3isIgPouyUr8yGJlFeL9Trg/umG5ogAvrjAYvQ8gV7daKDoQSRnJKWI2JFpQqRsuQ==",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.17",
         "@firebase/logger": "0.4.4",
@@ -1316,7 +1256,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.0.tgz",
       "integrity": "sha512-LjLUrzbUgTa/sCtPoLKT2C7KShvLVHS3crnU1Du02YxnGVLE0CUBGY/NxgfR/Zg84mEbj1q08/dgesojxjn0dA==",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.13.0",
         "@firebase/component": "0.6.17",
@@ -1331,8 +1270,7 @@
     "node_modules/@firebase/app-types": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
-      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
-      "peer": true
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
     },
     "node_modules/@firebase/auth": {
       "version": "1.10.6",
@@ -1914,7 +1852,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.0.tgz",
       "integrity": "sha512-Z4rK23xBCwgKDqmzGVMef+Vb4xso2j5Q8OG0vVL4m4fA5ZjPMYQazu8OJJC3vtQRC3SQ/Pgx/6TPNVsCd70QRw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2818,8 +2755,7 @@
     },
     "node_modules/@levante-framework/levante-zod": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.2.4.tgz",
-      "integrity": "sha512-F3D+58kMVjYG4IQMqsAzTEYdktL3QfJM18yXADuKWIldkxzzVaIa+SYU0fY1tpel384468TKqSGOcWACwTKkKQ==",
+      "resolved": "git+ssh://git@github.com/levante-framework/levante-zod.git#53d49827e4994b62146a4dafc05b8be61a63f875",
       "license": "MIT",
       "dependencies": {
         "h3-js": "^4.4.0",
@@ -2903,7 +2839,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.3.tgz",
       "integrity": "sha512-by1leTfZkwGycPKRWpc+p5/IhpnOj8zaScVi4RRm9fMoFYS3IE87Wzx1Yf/ruVYowXOEuLqYY3VmJw5tU3+0Bg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -2958,7 +2893,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.3.tgz",
       "integrity": "sha512-rRK9YOvgsAU/+edjgubL1q1FyCMjBZZs+fAWtD36tklawkh6WZV07sNLVSceuni+a21oby6xoad+3R8dfztOrA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.3",
         "@firebase/component": "0.7.0",
@@ -2974,8 +2908,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@levante-framework/permissions-core/node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -3690,7 +3623,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4336,7 +4268,6 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -4362,7 +4293,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
       "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4638,7 +4568,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5072,6 +5001,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
       "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -5083,7 +5013,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
       "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6321,8 +6250,7 @@
       "version": "0.0.1439962",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1439962.tgz",
       "integrity": "sha512-jJF48UdryzKiWhJ1bLKr7BFWUQCEIT5uCNbDLqkQJBtkFxYzILJH44WN0PDKMIlGDN7Utb8vyUY85C3w4R/t2g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -6425,27 +6353,6 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -6922,7 +6829,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8502,7 +8408,6 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
       "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -8601,9 +8506,9 @@
       }
     },
     "node_modules/h3-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
-      "integrity": "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.5.0.tgz",
+      "integrity": "sha512-uKmdPc+DuarnR+XqZxEuWOMw7KzzKROrx3MLeJpFnMOs78S9M5eZ+X5RieS9UcSFQqbeXzbfWuX/W9Pyajinqw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4",
@@ -9771,7 +9676,6 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -9797,7 +9701,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10778,7 +10681,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
       "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.6.4",
         "pg-pool": "^3.6.2",
@@ -11336,6 +11238,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/random-words/-/random-words-1.3.0.tgz",
       "integrity": "sha512-brwCGe+DN9DqZrAQVNj1Tct1Lody6GrYL/7uei5wfjeQdacFyFd2h/51LNlOoBMzIKMS9xohuL4+wlF/z1g/xg==",
+      "peer": true,
       "dependencies": {
         "seedrandom": "^3.0.5"
       }
@@ -11657,7 +11560,8 @@
     "node_modules/seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -12579,7 +12483,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13002,7 +12905,6 @@
       "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -13116,7 +13018,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13130,7 +13031,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -13617,7 +13517,6 @@
       "version": "3.25.36",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.36.tgz",
       "integrity": "sha512-eRFS3i8T0IrpGdL8HQyqFAugGOn7jOjyGgGdtv5NY4Wkhi7lJDk732bNZ609YMIGFbLoaj6J69O1Mura23gfIw==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13628,319 +13527,6 @@
       "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
       "peerDependencies": {
         "zod": "^3.24.1"
-      }
-    },
-    "packages/common": {
-      "name": "@roar-firebase-functions/common",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@bdelab/roar-utils": "^1.1.0",
-        "@firebase/firestore": "^3.8.1",
-        "@google-cloud/secret-manager": "^4.2.2",
-        "axios": "^1.4.0",
-        "axios-oauth-1.0a": "^0.3.6",
-        "bcrypt": "^5.1.1",
-        "boolean": "^3.2.0",
-        "crc-32": "^1.2.2",
-        "dotenv": "^16.0.0",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1",
-        "lodash": "^4.17.21",
-        "status-code-enum": "^1.0.0",
-        "typescript": "^4.5.4",
-        "uuid": "^9.0.0"
-      },
-      "devDependencies": {
-        "prettier": "3.3.2"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/gse-yeatmanlab/functions": {
-      "name": "@roar-firebase-functions/gse-yeatmanlab",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@google-cloud/local-auth": "^2.1.1",
-        "@google-cloud/storage": "^6.8.0",
-        "@types/fs-extra": "^9.0.13",
-        "@types/json2csv": "^5.0.3",
-        "eslint-plugin-flowtype": "^8.0.3",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-react": "^7.32.2",
-        "exponential-backoff": "^3.1.0",
-        "firebase-admin": "^10.0.2",
-        "firebase-functions": "^3.18.0",
-        "fs-extra": "^10.1.0",
-        "google-auth-library": "^8.7.0",
-        "googleapis": "^109.0.1",
-        "json2csv": "^5.0.7",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40",
-        "papaparse": "^5.3.2"
-      },
-      "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.59.9",
-        "@typescript-eslint/parser": "^5.12.0",
-        "eslint": "^8.42.0",
-        "eslint-config-google": "^0.14.0",
-        "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.1.1",
-        "eslint-plugin-standard": "^5.0.0",
-        "firebase-functions-test": "^0.2.0",
-        "prettier": "^2.8.8",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/levante-admin": {
-      "name": "@roar-firebase-functions/levante-admin",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@bdelab/roar-utils": "^1.1.0",
-        "@firebase/firestore": "^3.8.1",
-        "@google-cloud/secret-manager": "^4.2.2",
-        "axios": "^1.4.0",
-        "axios-oauth-1.0a": "^0.3.6",
-        "bcrypt": "^5.1.1",
-        "boolean": "^3.2.0",
-        "crc-32": "^1.2.2",
-        "dotenv": "^16.0.0",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1",
-        "lodash": "^4.17.21",
-        "status-code-enum": "^1.0.0",
-        "typescript": "^4.5.4",
-        "uuid": "^9.0.0"
-      },
-      "devDependencies": {
-        "@types/bcrypt": "^5.0.2",
-        "firebase-functions-test": "^0.2.0",
-        "firebase-tools-with-isolate": "^13.11.2",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/levante-admin/functions": {
-      "name": "@roar-firebase-functions/levante-admin",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@roar-firebase-functions/common": "file:../../common",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1",
-        "lodash": "^4.17.21"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/levante-assessment": {
-      "name": "@roar-firebase-functions/levante-assessment",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@roar-firebase-functions/common": "file:../../common",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1",
-        "lodash": "^4.17.21"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "firebase-tools-with-isolate": "^13.11.2",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/levante-assessment/functions": {
-      "name": "@roar-firebase-functions/levante-assessment",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@roar-firebase-functions/common": "file:../../common",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/local": {
-      "name": "@roar-firebase-functions/local",
-      "version": "1.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@faker-js/faker": "^8.3.1",
-        "axios": "^1.5.0",
-        "cli-progress": "^3.12.0",
-        "dot-object": "^2.1.4",
-        "firebase-admin": "^12.5.0",
-        "lodash": "^4.17.21",
-        "papaparse": "^5.4.1",
-        "prompt-confirm": "^2.0.4",
-        "queue": "^7.0.0",
-        "typescript": "^5.1.6",
-        "yargs": "^17.7.2"
-      },
-      "devDependencies": {
-        "@types/dot-object": "^2.1.3",
-        "@types/node": "^20.6.0",
-        "@types/papaparse": "^5.3.8",
-        "@types/yargs": "^17.0.32",
-        "@typescript-eslint/eslint-plugin": "^5.12.0",
-        "@typescript-eslint/parser": "^5.12.0",
-        "eslint": "^8.9.0",
-        "eslint-config-google": "^0.14.0",
-        "eslint-plugin-import": "^2.25.4",
-        "prettier": "^2.8.1",
-        "tsx": "^4.1.3"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/roar-admin": {
-      "name": "@roar-firebase-functions/roar-admin",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@google-cloud/pubsub": "^4.5.0",
-        "@roar-firebase-functions/common": "file:../../common",
-        "axios-retry": "^4.4.2",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "firebase-tools-with-isolate": "^13.11.2",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/roar-admin/functions": {
-      "name": "@roar-firebase-functions/roar-admin",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@roar-firebase-functions/common": "file:../../common",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "firebase-tools-with-isolate": "^13.11.2",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/roar-assessment": {
-      "name": "@roar-firebase-functions/roar-assessment",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@roar-firebase-functions/common": "file:../../common",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "firebase-tools-with-isolate": "^13.11.2",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/roar-assessment/functions": {
-      "name": "@roar-firebase-functions/roar-assessment",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@roar-firebase-functions/common": "file:../../common",
-        "firebase-admin": "^11.9.0",
-        "firebase-functions": "^4.4.1"
-      },
-      "devDependencies": {
-        "firebase-functions-test": "^0.2.0",
-        "prettier": "2.8.3",
-        "typescript": "^4.5.4"
-      },
-      "engines": {
-        "node": "20"
-      }
-    },
-    "packages/roar-local": {
-      "name": "@roar-firebase-functions/roar-local",
-      "version": "1.0.0",
-      "extraneous": true,
-      "license": "Stanford Academic Software License for ROAR",
-      "dependencies": {
-        "@faker-js/faker": "^8.3.1",
-        "axios": "^1.5.0",
-        "cli-progress": "^3.12.0",
-        "dot-object": "^2.1.4",
-        "firebase-admin": "^12.5.0",
-        "lodash": "^4.17.21",
-        "papaparse": "^5.4.1",
-        "prompt-confirm": "^2.0.4",
-        "queue": "^7.0.0",
-        "typescript": "^5.1.6",
-        "yargs": "^17.7.2"
-      },
-      "devDependencies": {
-        "@types/dot-object": "^2.1.3",
-        "@types/node": "^20.6.0",
-        "@types/papaparse": "^5.3.8",
-        "@types/yargs": "^17.0.32",
-        "@typescript-eslint/eslint-plugin": "^5.12.0",
-        "@typescript-eslint/parser": "^5.12.0",
-        "eslint": "^8.9.0",
-        "eslint-config-google": "^0.14.0",
-        "eslint-plugin-import": "^2.25.4",
-        "prettier": "^2.8.1",
-        "tsx": "^4.1.3"
-      },
-      "engines": {
-        "node": "20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "emulator:seed:legacy": "EMULATOR=1 node emulator_scripts/seed-emulator.js",
     "emulator:seed:functions": "EMULATOR=1 node emulator_scripts/seed-emulator-functions.js",
     "emulator:seed:tasks": "EMULATOR=1 node emulator_scripts/seed-tasks-from-project.js",
+    "emulator:seed:forms": "EMULATOR=1 node emulator_scripts/seed-form-definitions.js",
     "emulator:seed:ui": "node emulator_scripts/seed-emulator-ui.js",
     "emulator:start:dashboard": "node emulator_scripts/start-seeded-dashboard.js",
     "emulator:test:admin-login": "node emulator_scripts/test-admin-login.js",


### PR DESCRIPTION
## Summary

Callables for site/school information forms.

- `loadFormDefinitions` (#109): returns the registered form definition. `savedResponses` is `[]` in v1.
- `saveOrgInformation` (#110): merge-writes responses to
  - `districts/{orgId}/siteInformation/response`
  - `schools/{orgId}/schoolInformation/response`
- Auth: authenticated + superadmin
- Zod: validates the request shape only (`responses` values are not checked). GitHub branch dep until [levante-zod#34](https://github.com/levante-framework/levante-zod/pull/34) publishes.

Depends on [levante-zod#34](https://github.com/levante-framework/levante-zod/pull/34). UI: [levante-dashboard#1015](https://github.com/levante-framework/levante-dashboard/pull/1015).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [x] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Test plan

- [x] `npm run test:e2e`
- [x] Manual UI: [levante-dashboard#1015](https://github.com/levante-framework/levante-dashboard/pull/1015)