### PR TITLE
Add Firestore write audit journal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Run audit tests
+        run: npm run test:audit
+
       # - name: Run e2e tests
       #   run: npm run test:e2e

--- a/__tests__/e2e/audit/journalWrite.e2e.test.ts
+++ b/__tests__/e2e/audit/journalWrite.e2e.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { adminDb, clearFirestore } from "../app";
+import { handleJournalWrite } from "../../../functions/levante-admin/src/audit/journalWrite.js";
+import type {
+  AuditFirestoreEvent,
+  AuditDocumentSnapshot,
+  DeadLetterMessage,
+  JournalRow,
+} from "../../../functions/levante-admin/src/audit/types.js";
+
+const asAuditSnapshot = (
+  snapshot: FirebaseFirestore.DocumentSnapshot
+): AuditDocumentSnapshot => snapshot as unknown as AuditDocumentSnapshot;
+
+const eventFor = (
+  id: string,
+  before: FirebaseFirestore.DocumentSnapshot,
+  after: FirebaseFirestore.DocumentSnapshot
+): AuditFirestoreEvent => ({
+  id,
+  time: "2026-08-14T12:00:00.000Z",
+  document: "users/test-user",
+  data: {
+    before: asAuditSnapshot(before),
+    after: asAuditSnapshot(after),
+  },
+});
+
+describe("journalWrite emulator-backed snapshots", () => {
+  beforeEach(async () => {
+    await clearFirestore();
+  });
+
+  it("builds expected rows for create, update, and delete snapshots", async () => {
+    const rows: JournalRow[] = [];
+    const publish = vi.fn<(_: DeadLetterMessage) => Promise<void>>();
+    const dependencies = {
+      journalWriter: {
+        insert: async (row: JournalRow) => {
+          rows.push(row);
+        },
+      },
+      deadLetterPublisher: { publish },
+      logger: { error: vi.fn() },
+    };
+    const ref = adminDb.doc("users/test-user");
+
+    const beforeCreate = await ref.get();
+    await ref.set({
+      displayName: "Test User",
+      _audit: { actor: "tester", request_id: "request-create" },
+    });
+    const afterCreate = await ref.get();
+    await handleJournalWrite(
+      eventFor("event-create", beforeCreate, afterCreate),
+      dependencies
+    );
+
+    const beforeUpdate = await ref.get();
+    await ref.update({
+      displayName: "Updated Test User",
+      _audit: { actor: "tester", request_id: "request-update" },
+    });
+    const afterUpdate = await ref.get();
+    await handleJournalWrite(
+      eventFor("event-update", beforeUpdate, afterUpdate),
+      dependencies
+    );
+
+    const beforeDelete = await ref.get();
+    await ref.delete();
+    const afterDelete = await ref.get();
+    await handleJournalWrite(
+      eventFor("event-delete", beforeDelete, afterDelete),
+      dependencies
+    );
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.operation)).toEqual([
+      "create",
+      "update",
+      "delete",
+    ]);
+    expect(rows.map((row) => row.resource_path)).toEqual([
+      "users/test-user",
+      "users/test-user",
+      "users/test-user",
+    ]);
+    expect(rows.map((row) => row.request_id)).toEqual([
+      "request-create",
+      "request-update",
+      "request-update",
+    ]);
+    expect(rows[0].before_json).toBeNull();
+    expect(JSON.parse(rows[0].after_json ?? "{}")).toMatchObject({
+      displayName: "Test User",
+    });
+    expect(rows[2].after_json).toBeNull();
+    expect(JSON.parse(rows[2].before_json ?? "{}")).toMatchObject({
+      displayName: "Updated Test User",
+    });
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/functions/levante-admin/scripts/audit/create_dataset.sh
+++ b/functions/levante-admin/scripts/audit/create_dataset.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT="${1:-hs-levante-admin-dev}"
+DATASET="levante_audit"
+LOCATION="US"
+TABLE="writes_journal"
+DLQ_TOPIC="levante-audit-journal-dlq"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! bq show --format=none "${PROJECT}:${DATASET}" >/dev/null 2>&1; then
+  bq --location="$LOCATION" mk --dataset \
+    --description "LEVANTE Firestore write journal and audit tables" \
+    "${PROJECT}:${DATASET}"
+fi
+
+if ! bq show --format=none "${PROJECT}:${DATASET}.${TABLE}" >/dev/null 2>&1; then
+  bq mk --table \
+    --time_partitioning_field commit_timestamp \
+    --time_partitioning_type DAY \
+    --clustering_fields resource_path,operation \
+    --description "Append-only journal of Firestore writes" \
+    "${PROJECT}:${DATASET}.${TABLE}" \
+    "${SCRIPT_DIR}/writes_journal_schema.json"
+fi
+
+if ! gcloud pubsub topics describe "$DLQ_TOPIC" \
+  --project "$PROJECT" >/dev/null 2>&1; then
+  gcloud pubsub topics create "$DLQ_TOPIC" \
+    --project "$PROJECT"
+fi

--- a/functions/levante-admin/scripts/audit/query_journal.mjs
+++ b/functions/levante-admin/scripts/audit/query_journal.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+
+const DATASET = "levante_audit";
+const TABLE = "writes_journal";
+const DEFAULT_PROJECT = "hs-levante-admin-dev";
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+const usage = `
+Usage:
+  node functions/levante-admin/scripts/audit/query_journal.mjs [options]
+
+Options:
+  --project <id>              Firebase/GCP project. Default: ${DEFAULT_PROJECT}
+  --hours <n>                 Look back this many hours. Default: 24
+  --start <iso>               Inclusive start timestamp.
+  --end <iso>                 Inclusive end timestamp. Default: now
+  --resource <path>           Exact Firestore document path.
+  --resource-prefix <prefix>  Firestore document path prefix.
+  --operation <op>            create, update, or delete.
+  --actor <actor>             _audit.actor value.
+  --request-id <id>           _audit.request_id value.
+  --truncated <bool>          true or false for payload_truncated.
+  --include-payloads          Include before_json and after_json.
+  --limit <n>                 Max rows, capped at ${MAX_LIMIT}. Default: ${DEFAULT_LIMIT}
+  --page-token <token>        BigQuery page token from a previous run.
+  --format <table|json>       Output format. Default: table
+  --help                      Show this message.
+
+Authentication:
+  Uses GOOGLE_OAUTH_ACCESS_TOKEN when set, otherwise runs
+  "gcloud auth print-access-token" with your active user credentials.
+`;
+
+const parseArgs = (argv) => {
+  const options = {
+    project: DEFAULT_PROJECT,
+    format: "table",
+    includePayloads: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case "--project":
+        options.project = next();
+        break;
+      case "--hours":
+        options.hours = Number(next());
+        break;
+      case "--start":
+        options.start = next();
+        break;
+      case "--end":
+        options.end = next();
+        break;
+      case "--resource":
+        options.resource = next();
+        break;
+      case "--resource-prefix":
+        options.resourcePrefix = next();
+        break;
+      case "--operation":
+        options.operation = next();
+        break;
+      case "--actor":
+        options.actor = next();
+        break;
+      case "--request-id":
+        options.requestId = next();
+        break;
+      case "--truncated":
+        options.truncated = parseBoolean(next(), "--truncated");
+        break;
+      case "--include-payloads":
+        options.includePayloads = true;
+        break;
+      case "--limit":
+        options.limit = Number(next());
+        break;
+      case "--page-token":
+        options.pageToken = next();
+        break;
+      case "--format":
+        options.format = next();
+        break;
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+};
+
+const parseBoolean = (value, flag) => {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${flag} must be true or false`);
+};
+
+const isoDate = (value, fallback, field) => {
+  if (!value) return fallback.toISOString();
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${field} must be a valid date`);
+  }
+  return date.toISOString();
+};
+
+const getAccessToken = () => {
+  if (process.env.GOOGLE_OAUTH_ACCESS_TOKEN) {
+    return process.env.GOOGLE_OAUTH_ACCESS_TOKEN;
+  }
+
+  return execFileSync("gcloud", ["auth", "print-access-token"], {
+    encoding: "utf8",
+  }).trim();
+};
+
+const queryParameter = (name, type, value) => ({
+  name,
+  parameterType: { type },
+  parameterValue: { value: String(value) },
+});
+
+const buildQuery = (options) => {
+  const now = new Date();
+  const hours =
+    typeof options.hours === "number" && Number.isFinite(options.hours)
+      ? options.hours
+      : 24;
+  const defaultStart = new Date(now.getTime() - hours * 60 * 60 * 1000);
+  const startTime = isoDate(options.start, defaultStart, "--start");
+  const endTime = isoDate(options.end, now, "--end");
+  const limit = Math.min(
+    Math.max(
+      Number.isInteger(options.limit) ? options.limit : DEFAULT_LIMIT,
+      1
+    ),
+    MAX_LIMIT
+  );
+  const payloadColumns = options.includePayloads
+    ? [
+        "TO_JSON_STRING(before_json) AS before_json",
+        "TO_JSON_STRING(after_json) AS after_json",
+      ]
+    : [
+        "CAST(NULL AS STRING) AS before_json",
+        "CAST(NULL AS STRING) AS after_json",
+      ];
+  const whereClauses = [
+    "commit_timestamp >= @startTime",
+    "commit_timestamp <= @endTime",
+  ];
+  const queryParameters = [
+    queryParameter("startTime", "TIMESTAMP", startTime),
+    queryParameter("endTime", "TIMESTAMP", endTime),
+    queryParameter("limit", "INT64", limit),
+  ];
+
+  if (options.resource) {
+    whereClauses.push("resource_path = @resourcePath");
+    queryParameters.push(
+      queryParameter("resourcePath", "STRING", options.resource)
+    );
+  }
+  if (options.resourcePrefix) {
+    whereClauses.push("STARTS_WITH(resource_path, @resourcePathPrefix)");
+    queryParameters.push(
+      queryParameter("resourcePathPrefix", "STRING", options.resourcePrefix)
+    );
+  }
+  if (options.operation) {
+    if (!["create", "update", "delete"].includes(options.operation)) {
+      throw new Error("--operation must be create, update, or delete");
+    }
+    whereClauses.push("operation = @operation");
+    queryParameters.push(
+      queryParameter("operation", "STRING", options.operation)
+    );
+  }
+  if (options.actor) {
+    whereClauses.push("actor = @actor");
+    queryParameters.push(queryParameter("actor", "STRING", options.actor));
+  }
+  if (options.requestId) {
+    whereClauses.push("request_id = @requestId");
+    queryParameters.push(
+      queryParameter("requestId", "STRING", options.requestId)
+    );
+  }
+  if (typeof options.truncated === "boolean") {
+    whereClauses.push("payload_truncated = @payloadTruncated");
+    queryParameters.push(
+      queryParameter("payloadTruncated", "BOOL", options.truncated)
+    );
+  }
+
+  return {
+    maxResults: limit,
+    parameterMode: "NAMED",
+    query: `
+      SELECT
+        event_id,
+        FORMAT_TIMESTAMP('%FT%T%Ez', commit_timestamp) AS commit_timestamp,
+        FORMAT_TIMESTAMP('%FT%T%Ez', ingest_timestamp) AS ingest_timestamp,
+        resource_path,
+        operation,
+        actor,
+        request_id,
+        ${payloadColumns.join(",\n        ")},
+        payload_bytes,
+        payload_truncated,
+        payload_sha256
+      FROM \`${options.project}.${DATASET}.${TABLE}\`
+      WHERE ${whereClauses.join("\n        AND ")}
+      ORDER BY commit_timestamp DESC
+      LIMIT @limit
+    `,
+    queryParameters,
+    useLegacySql: false,
+    ...(options.pageToken && { pageToken: options.pageToken }),
+  };
+};
+
+const rowsFromResponse = (body) => {
+  const fields = body.schema?.fields ?? [];
+  return (body.rows ?? []).map((row) =>
+    Object.fromEntries(
+      row.f.map((field, index) => [fields[index]?.name, field.v])
+    )
+  );
+};
+
+const printRows = (rows, format, nextPageToken) => {
+  if (format === "json") {
+    console.log(JSON.stringify({ rows, nextPageToken }, null, 2));
+    return;
+  }
+  if (format !== "table") {
+    throw new Error("--format must be table or json");
+  }
+
+  console.table(
+    rows.map((row) => ({
+      commit_timestamp: row.commit_timestamp,
+      operation: row.operation,
+      resource_path: row.resource_path,
+      actor: row.actor,
+      request_id: row.request_id,
+      payload_bytes: row.payload_bytes,
+      payload_truncated: row.payload_truncated,
+      event_id: row.event_id,
+    }))
+  );
+
+  if (nextPageToken) {
+    console.log(`Next page token: ${nextPageToken}`);
+  }
+};
+
+const main = async () => {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage.trim());
+    return;
+  }
+
+  const accessToken = getAccessToken();
+  const response = await fetch(
+    `https://bigquery.googleapis.com/bigquery/v2/projects/${options.project}/queries`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(buildQuery(options)),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `BigQuery query failed with ${response.status}: ${await response.text()}`
+    );
+  }
+
+  const body = await response.json();
+  if (body.jobComplete === false) {
+    throw new Error("BigQuery query did not complete synchronously");
+  }
+  if (body.errors?.length) {
+    throw new Error(
+      `BigQuery query failed: ${body.errors
+        .map((error) => error.message)
+        .filter(Boolean)
+        .join("; ")}`
+    );
+  }
+
+  printRows(rowsFromResponse(body), options.format, body.pageToken);
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/functions/levante-admin/scripts/audit/writes_journal_schema.json
+++ b/functions/levante-admin/scripts/audit/writes_journal_schema.json
@@ -1,0 +1,14 @@
+[
+  { "name": "event_id", "type": "STRING", "mode": "REQUIRED" },
+  { "name": "commit_timestamp", "type": "TIMESTAMP", "mode": "REQUIRED" },
+  { "name": "ingest_timestamp", "type": "TIMESTAMP", "mode": "REQUIRED" },
+  { "name": "resource_path", "type": "STRING", "mode": "REQUIRED" },
+  { "name": "operation", "type": "STRING", "mode": "REQUIRED" },
+  { "name": "actor", "type": "STRING", "mode": "NULLABLE" },
+  { "name": "request_id", "type": "STRING", "mode": "NULLABLE" },
+  { "name": "before_json", "type": "JSON", "mode": "NULLABLE" },
+  { "name": "after_json", "type": "JSON", "mode": "NULLABLE" },
+  { "name": "payload_bytes", "type": "INT64", "mode": "REQUIRED" },
+  { "name": "payload_truncated", "type": "BOOL", "mode": "REQUIRED" },
+  { "name": "payload_sha256", "type": "STRING", "mode": "NULLABLE" }
+]

--- a/functions/levante-admin/src/audit/README.md
+++ b/functions/levante-admin/src/audit/README.md
@@ -2,7 +2,7 @@
 
 ## What This Does
 
-`journalWrite` is a Firebase Cloud Functions v2 Firestore trigger that records application writes from the default Firestore database into a BigQuery append-only journal. Each row includes the Firestore event ID, document path, operation, commit time, ingest time, before/after payloads, and optional `_audit.actor` and `_audit.request_id` metadata when callers stamp it on the document.
+`journalWrite` is a Firebase Cloud Functions v2 Firestore trigger that records application writes from the default Firestore database into a BigQuery append-only journal. Each row includes the Firestore event ID, document path, operation, commit time, ingest time, before/after payloads, and optional `_audit.actor` and `_audit.request_id` metadata when callers stamp it on the document. `getAuditJournalRows` is a super-admin-only callable for reading bounded slices of the journal from dashboard tooling.
 
 ## Coverage And Known Gaps
 
@@ -22,6 +22,12 @@ The BigQuery schema is checked in at `functions/levante-admin/scripts/audit/writ
 
 The table is partitioned by `commit_timestamp` and clustered by `resource_path,operation`. `before_json` and `after_json` are nullable JSON columns. Payloads larger than 256 KiB are replaced with null JSON values and a stable `payload_sha256` so the journal keeps change-detection value without storing oversized documents.
 
+## Query Endpoint
+
+`getAuditJournalRows` is an HTTPS callable intended for super-admin dashboard tooling. It accepts optional filters for `startTime`, `endTime`, `resourcePath`, `resourcePathPrefix`, `operation`, `actor`, `requestId`, `payloadTruncated`, `includePayloads`, `limit`, and `pageToken`.
+
+The callable defaults to the last 24 hours, caps `limit` at 100 rows, and returns payload columns as `null` unless `includePayloads` is explicitly `true`. Keep dashboard views metadata-first and require an explicit expand action before showing `before_json` or `after_json`, because those payloads may contain PII.
+
 ## Deploy
 
 Create the dataset, table, and DLQ topic before deploying the function:
@@ -30,10 +36,10 @@ Create the dataset, table, and DLQ topic before deploying the function:
 functions/levante-admin/scripts/audit/create_dataset.sh hs-levante-admin-dev
 ```
 
-Deploy only the dev trigger:
+Deploy only the dev audit functions:
 
 ```bash
-firebase deploy --only functions:journalWrite --project hs-levante-admin-dev
+firebase deploy --only functions:levante-admin:journalWrite,functions:levante-admin:getAuditJournalRows --project hs-levante-admin-dev
 ```
 
 Do not run a production deploy for this PR.
@@ -43,6 +49,7 @@ Do not run a production deploy for this PR.
 Apply these grants once for the functions runtime service account in the target project. Keep the grants in the infra runbook; do not apply them from application code.
 
 - `roles/bigquery.dataEditor` on dataset `levante_audit`.
+- `roles/bigquery.jobUser` on project `hs-levante-admin-dev` so the query endpoint can run BigQuery jobs.
 - `roles/pubsub.publisher` on topic `levante-audit-journal-dlq`.
 
 No new Firestore role is required for the trigger. Eventarc/Functions v2 provides Firestore event delivery through the standard trigger wiring.

--- a/functions/levante-admin/src/audit/README.md
+++ b/functions/levante-admin/src/audit/README.md
@@ -82,6 +82,41 @@ Promotion criteria:
 
 Table retention is intentionally left at the BigQuery default in this PR. Decide the partition expiration, such as 400 days, in the follow-up production PR after the audit retention policy is agreed on.
 
+## Production Rollout Checklist
+
+Do not start this checklist until the dev volume test has enough data to make a promotion decision.
+
+- Review dev daily row count, byte volume, truncation rate, DLQ errors, trigger latency, and estimated BigQuery cost.
+- Confirm promotion criteria are met: less than 1% truncation, zero sustained DLQ errors, and ingest cost within the team-approved budget.
+- Decide the production retention policy and whether to set a partition expiration on `writes_journal`.
+- Merge the audit journal PR before deploying from `main`.
+- Create production audit resources:
+
+  ```bash
+  functions/levante-admin/scripts/audit/create_dataset.sh hs-levante-admin-prod
+  ```
+
+- Grant the production functions runtime service account:
+  - `roles/bigquery.dataEditor` on dataset `levante_audit`.
+  - `roles/bigquery.jobUser` on project `hs-levante-admin-prod`.
+  - `roles/pubsub.publisher` on topic `levante-audit-journal-dlq`.
+- Prefer dataset-level BigQuery access in production. Avoid the broader project-level `roles/bigquery.dataEditor` fallback unless dataset IAM cannot be applied and the team explicitly accepts the wider grant.
+- Deploy only the production audit functions:
+
+  ```bash
+  firebase deploy --only functions:levante-admin:journalWrite,functions:levante-admin:getAuditJournalRows --project hs-levante-admin-prod
+  ```
+
+- Smoke test with a production-safe synthetic write/update/delete, then confirm rows appear in `hs-levante-admin-prod.levante_audit.writes_journal`.
+- Confirm the local query script can read production rows:
+
+  ```bash
+  npm run audit:journal -- --project hs-levante-admin-prod --limit 5
+  ```
+
+- Add monitoring for `component="audit.journalWrite"` errors, DLQ messages, daily row count, and daily bytes.
+- Remember that `_audit.actor` and `_audit.request_id` may remain `null` until the dashboard and client-helper stamping follow-ups ship.
+
 ## Runbook: Bulk Restores
 
 Firestore import and restore operations do not fire this trigger. Anyone running `FirestoreAdmin.ImportDocuments` must, in the same change ticket, run the future `scripts/audit/journal_backfill.ts` companion after the import completes. That script should read the imported document IDs and write synthetic journal rows with `actor = "import:<ticket-id>"`.

--- a/functions/levante-admin/src/audit/README.md
+++ b/functions/levante-admin/src/audit/README.md
@@ -28,6 +28,17 @@ The table is partitioned by `commit_timestamp` and clustered by `resource_path,o
 
 The callable defaults to the last 24 hours, caps `limit` at 100 rows, and returns payload columns as `null` unless `includePayloads` is explicitly `true`. Keep dashboard views metadata-first and require an explicit expand action before showing `before_json` or `after_json`, because those payloads may contain PII.
 
+For immediate debugging without dashboard UI, use the local script. It relies on the active user's `gcloud` credentials, defaults to `hs-levante-admin-dev`, and also hides payloads unless `--include-payloads` is set.
+
+```bash
+npm run audit:journal
+npm run audit:journal -- --resource-prefix users/ --operation update --limit 25
+npm run audit:journal -- --actor admin@example.test --format json
+npm run audit:journal -- --include-payloads --resource users/test-user
+```
+
+Run `npm run audit:journal -- --help` for all filters. The caller needs BigQuery permissions to create query jobs and read `levante_audit.writes_journal`.
+
 ## Deploy
 
 Create the dataset, table, and DLQ topic before deploying the function:

--- a/functions/levante-admin/src/audit/README.md
+++ b/functions/levante-admin/src/audit/README.md
@@ -1,0 +1,82 @@
+# Firestore Write Journal
+
+## What This Does
+
+`journalWrite` is a Firebase Cloud Functions v2 Firestore trigger that records application writes from the default Firestore database into a BigQuery append-only journal. Each row includes the Firestore event ID, document path, operation, commit time, ingest time, before/after payloads, and optional `_audit.actor` and `_audit.request_id` metadata when callers stamp it on the document.
+
+## Coverage And Known Gaps
+
+This first slice is intended for `hs-levante-admin-dev` only. Do not deploy it to production until the dev volume test has run and the team has agreed on retention and cost thresholds.
+
+The trigger covers writes in the default Firestore database for the project where the function is deployed. It does not cover named databases such as `levante-tools-data`; that requires a separate trigger declaration.
+
+`FirestoreAdmin.ImportDocuments` restore/import operations do not fire document write triggers. Anyone using bulk import or restore paths must follow the bulk restore runbook below.
+
+Read-side auditing is not handled here. It should be covered separately by enabling Cloud Audit Data Access logs through infrastructure.
+
+This PR does not stamp `_audit.request_id` or `_audit.actor` in the dashboard, Node helpers, or Python helpers. Those are cross-repo follow-ups.
+
+## Row Schema
+
+The BigQuery schema is checked in at `functions/levante-admin/scripts/audit/writes_journal_schema.json`.
+
+The table is partitioned by `commit_timestamp` and clustered by `resource_path,operation`. `before_json` and `after_json` are nullable JSON columns. Payloads larger than 256 KiB are replaced with null JSON values and a stable `payload_sha256` so the journal keeps change-detection value without storing oversized documents.
+
+## Deploy
+
+Create the dataset, table, and DLQ topic before deploying the function:
+
+```bash
+functions/levante-admin/scripts/audit/create_dataset.sh hs-levante-admin-dev
+```
+
+Deploy only the dev trigger:
+
+```bash
+firebase deploy --only functions:journalWrite --project hs-levante-admin-dev
+```
+
+Do not run a production deploy for this PR.
+
+## IAM
+
+Apply these grants once for the functions runtime service account in the target project. Keep the grants in the infra runbook; do not apply them from application code.
+
+- `roles/bigquery.dataEditor` on dataset `levante_audit`.
+- `roles/pubsub.publisher` on topic `levante-audit-journal-dlq`.
+
+No new Firestore role is required for the trigger. Eventarc/Functions v2 provides Firestore event delivery through the standard trigger wiring.
+
+## Volume Test Plan
+
+Deploy to `hs-levante-admin-dev` and let the trigger run for 3 to 7 days. Check the following before promoting to production:
+
+- Daily row count and byte volume in `levante_audit.writes_journal`.
+- Fraction of rows with `payload_truncated = true`.
+- Any messages or publish failures for `levante-audit-journal-dlq`.
+- P95 trigger latency in Cloud Logging.
+
+Promotion criteria:
+
+- Less than 1% truncation rate on real dev traffic.
+- Zero sustained DLQ errors.
+- Daily BigQuery ingest cost is within the budget agreed on by the team.
+
+Table retention is intentionally left at the BigQuery default in this PR. Decide the partition expiration, such as 400 days, in the follow-up production PR after the audit retention policy is agreed on.
+
+## Runbook: Bulk Restores
+
+Firestore import and restore operations do not fire this trigger. Anyone running `FirestoreAdmin.ImportDocuments` must, in the same change ticket, run the future `scripts/audit/journal_backfill.ts` companion after the import completes. That script should read the imported document IDs and write synthetic journal rows with `actor = "import:<ticket-id>"`.
+
+`journal_backfill.ts` is not implemented in this PR. Track it as a follow-up before relying on import/restore paths for complete audit history.
+
+## Follow-Ups
+
+- Cross-repo PRs to stamp `_audit.request_id` and `_audit.actor` in Web, Node, and Python Firestore client helpers.
+- Second trigger for the `levante-tools-data` named database.
+- Production deploy after the dev volume test.
+- `journal_backfill.ts` for import and restore paths.
+- Log-based alert on `google.firestore.admin.v1.FirestoreAdmin.ImportDocuments` in infra.
+- Log-based alert on `severity=ERROR AND jsonPayload.component="audit.journalWrite"`.
+- DLQ replay tool.
+- Retention and partition-expiration decision.

--- a/functions/levante-admin/src/audit/bigqueryClient.test.ts
+++ b/functions/levante-admin/src/audit/bigqueryClient.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
-import { BigQueryJournalWriter } from "./bigqueryClient.js";
-import { AUDIT_DATASET, AUDIT_WRITES_TABLE, type JournalRow } from "./types.js";
+import {
+  BigQueryAuditJournalReader,
+  BigQueryJournalWriter,
+  buildAuditJournalQuery,
+} from "./bigqueryClient.js";
+import {
+  AUDIT_DATASET,
+  AUDIT_WRITES_TABLE,
+  type JournalRow,
+  type RequiredAuditJournalQueryParams,
+} from "./types.js";
 
 const row: JournalRow = {
   event_id: "event-1",
@@ -15,6 +24,20 @@ const row: JournalRow = {
   payload_bytes: 11,
   payload_truncated: false,
   payload_sha256: null,
+};
+
+const queryParams: RequiredAuditJournalQueryParams = {
+  startTime: "2026-08-14T00:00:00.000Z",
+  endTime: "2026-08-15T00:00:00.000Z",
+  resourcePath: null,
+  resourcePathPrefix: "users/",
+  operation: "update",
+  actor: "admin-user",
+  requestId: null,
+  payloadTruncated: false,
+  includePayloads: false,
+  limit: 25,
+  pageToken: null,
 };
 
 describe("BigQueryJournalWriter", () => {
@@ -42,6 +65,114 @@ describe("BigQueryJournalWriter", () => {
     });
     expect(JSON.parse(String(init?.body))).toEqual({
       rows: [{ insertId: "event-1", json: row }],
+    });
+  });
+});
+
+describe("BigQueryAuditJournalReader", () => {
+  it("builds a bounded parameterized audit query", () => {
+    const { query, queryParameters } = buildAuditJournalQuery(
+      "test-project",
+      queryParams
+    );
+
+    expect(query).toContain("`test-project.levante_audit.writes_journal`");
+    expect(query).toContain("STARTS_WITH(resource_path, @resourcePathPrefix)");
+    expect(query).toContain("operation = @operation");
+    expect(query).toContain("payload_truncated = @payloadTruncated");
+    expect(query).toContain("CAST(NULL AS STRING) AS before_json");
+    expect(query).toContain("LIMIT @limit");
+    expect(queryParameters).toEqual(
+      expect.arrayContaining([
+        {
+          name: "resourcePathPrefix",
+          parameterType: { type: "STRING" },
+          parameterValue: { value: "users/" },
+        },
+        {
+          name: "payloadTruncated",
+          parameterType: { type: "BOOL" },
+          parameterValue: { value: "false" },
+        },
+      ])
+    );
+  });
+
+  it("executes the query and maps rows", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        jobComplete: true,
+        pageToken: "next-page",
+        schema: {
+          fields: [
+            { name: "event_id" },
+            { name: "commit_timestamp" },
+            { name: "ingest_timestamp" },
+            { name: "resource_path" },
+            { name: "operation" },
+            { name: "actor" },
+            { name: "request_id" },
+            { name: "before_json" },
+            { name: "after_json" },
+            { name: "payload_bytes" },
+            { name: "payload_truncated" },
+            { name: "payload_sha256" },
+          ],
+        },
+        rows: [
+          {
+            f: [
+              { v: "event-1" },
+              { v: "2026-08-14T00:00:00Z" },
+              { v: "2026-08-14T00:00:01Z" },
+              { v: "users/test-user" },
+              { v: "update" },
+              { v: "admin-user" },
+              { v: "request-1" },
+              { v: null },
+              { v: '{"ok":true}' },
+              { v: "11" },
+              { v: "false" },
+              { v: null },
+            ],
+          },
+        ],
+      }),
+    } as Response);
+
+    const result = await new BigQueryAuditJournalReader({
+      fetchImpl,
+      getAccessToken: async () => "token-1",
+      projectId: "test-project",
+    }).query({ ...queryParams, pageToken: "page-1" });
+
+    expect(result).toEqual({
+      nextPageToken: "next-page",
+      rows: [
+        {
+          event_id: "event-1",
+          commit_timestamp: "2026-08-14T00:00:00Z",
+          ingest_timestamp: "2026-08-14T00:00:01Z",
+          operation: "update",
+          resource_path: "users/test-user",
+          actor: "admin-user",
+          request_id: "request-1",
+          before_json: null,
+          after_json: '{"ok":true}',
+          payload_bytes: 11,
+          payload_truncated: false,
+          payload_sha256: null,
+        },
+      ],
+    });
+
+    const [, init] = fetchImpl.mock.calls[0];
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      useLegacySql: false,
+      parameterMode: "NAMED",
+      maxResults: 25,
+      pageToken: "page-1",
     });
   });
 });

--- a/functions/levante-admin/src/audit/bigqueryClient.test.ts
+++ b/functions/levante-admin/src/audit/bigqueryClient.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { BigQueryJournalWriter } from "./bigqueryClient.js";
+import { AUDIT_DATASET, AUDIT_WRITES_TABLE, type JournalRow } from "./types.js";
+
+const row: JournalRow = {
+  event_id: "event-1",
+  commit_timestamp: "2026-08-14T12:00:00.000Z",
+  ingest_timestamp: "2026-08-14T12:00:01.000Z",
+  resource_path: "users/test-user",
+  operation: "create",
+  actor: "user-1",
+  request_id: "request-1",
+  before_json: null,
+  after_json: '{"ok":true}',
+  payload_bytes: 11,
+  payload_truncated: false,
+  payload_sha256: null,
+};
+
+describe("BigQueryJournalWriter", () => {
+  it("streams rows with event_id as the insertId", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+    } as Response);
+
+    await new BigQueryJournalWriter({
+      fetchImpl,
+      getAccessToken: async () => "token-1",
+      projectId: "test-project",
+    }).insert(row);
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(String(url)).toBe(
+      `https://bigquery.googleapis.com/bigquery/v2/projects/test-project/datasets/${AUDIT_DATASET}/tables/${AUDIT_WRITES_TABLE}/insertAll`
+    );
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        Authorization: "Bearer token-1",
+        "Content-Type": "application/json",
+      },
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      rows: [{ insertId: "event-1", json: row }],
+    });
+  });
+});

--- a/functions/levante-admin/src/audit/bigqueryClient.ts
+++ b/functions/levante-admin/src/audit/bigqueryClient.ts
@@ -1,12 +1,30 @@
 import {
   AUDIT_DATASET,
   AUDIT_WRITES_TABLE,
+  type AuditJournalQueryResult,
+  type AuditJournalReader,
   type JournalRow,
   type JournalWriter,
+  type RequiredAuditJournalQueryParams,
 } from "./types.js";
 
 type FetchLike = typeof fetch;
 type TokenProvider = () => Promise<string>;
+type BigQueryParameterType = "BOOL" | "INT64" | "STRING" | "TIMESTAMP";
+
+type BigQueryQueryParameter = {
+  name: string;
+  parameterType: { type: BigQueryParameterType };
+  parameterValue: { value: string };
+};
+
+type BigQueryQueryResponse = {
+  jobComplete?: boolean;
+  pageToken?: string;
+  schema?: { fields?: Array<{ name: string }> };
+  rows?: Array<{ f: Array<{ v: unknown }> }>;
+  errors?: Array<{ message?: string }>;
+};
 
 const METADATA_TOKEN_URL =
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
@@ -82,5 +100,220 @@ export class BigQueryJournalWriter implements JournalWriter {
         }: ${await response.text()}`
       );
     }
+  }
+}
+
+const queryEndpoint = (projectId: string): URL =>
+  new URL(
+    `https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/queries`
+  );
+
+const authHeaders = (accessToken: string): Record<string, string> => ({
+  Authorization: `Bearer ${accessToken}`,
+  "Content-Type": "application/json",
+});
+
+const queryParameter = (
+  name: string,
+  type: BigQueryParameterType,
+  value: string | number | boolean
+): BigQueryQueryParameter => ({
+  name,
+  parameterType: { type },
+  parameterValue: { value: String(value) },
+});
+
+const rowValue = (
+  row: Record<string, unknown>,
+  key: keyof JournalRow
+): string | null => {
+  const value = row[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+const rowBool = (
+  row: Record<string, unknown>,
+  key: keyof JournalRow
+): boolean => row[key] === true || row[key] === "true";
+
+const rowNumber = (
+  row: Record<string, unknown>,
+  key: keyof JournalRow
+): number => Number(row[key] ?? 0);
+
+const mapQueryRows = (response: BigQueryQueryResponse): JournalRow[] => {
+  const fields = response.schema?.fields ?? [];
+  const rows = response.rows ?? [];
+
+  return rows.map((row) => {
+    const mapped = Object.fromEntries(
+      row.f.map((field, index) => [fields[index]?.name, field.v])
+    ) as Record<string, unknown>;
+
+    return {
+      event_id: rowValue(mapped, "event_id") ?? "",
+      commit_timestamp: rowValue(mapped, "commit_timestamp") ?? "",
+      ingest_timestamp: rowValue(mapped, "ingest_timestamp") ?? "",
+      resource_path: rowValue(mapped, "resource_path") ?? "",
+      operation: (rowValue(mapped, "operation") ??
+        "update") as JournalRow["operation"],
+      actor: rowValue(mapped, "actor"),
+      request_id: rowValue(mapped, "request_id"),
+      before_json: rowValue(mapped, "before_json"),
+      after_json: rowValue(mapped, "after_json"),
+      payload_bytes: rowNumber(mapped, "payload_bytes"),
+      payload_truncated: rowBool(mapped, "payload_truncated"),
+      payload_sha256: rowValue(mapped, "payload_sha256"),
+    };
+  });
+};
+
+export const buildAuditJournalQuery = (
+  projectId: string,
+  params: RequiredAuditJournalQueryParams
+): { query: string; queryParameters: BigQueryQueryParameter[] } => {
+  const payloadColumns = params.includePayloads
+    ? [
+        "TO_JSON_STRING(before_json) AS before_json",
+        "TO_JSON_STRING(after_json) AS after_json",
+      ]
+    : [
+        "CAST(NULL AS STRING) AS before_json",
+        "CAST(NULL AS STRING) AS after_json",
+      ];
+  const whereClauses = [
+    "commit_timestamp >= @startTime",
+    "commit_timestamp <= @endTime",
+  ];
+  const queryParameters = [
+    queryParameter("startTime", "TIMESTAMP", params.startTime),
+    queryParameter("endTime", "TIMESTAMP", params.endTime),
+    queryParameter("limit", "INT64", params.limit),
+  ];
+
+  if (params.resourcePath) {
+    whereClauses.push("resource_path = @resourcePath");
+    queryParameters.push(
+      queryParameter("resourcePath", "STRING", params.resourcePath)
+    );
+  }
+  if (params.resourcePathPrefix) {
+    whereClauses.push("STARTS_WITH(resource_path, @resourcePathPrefix)");
+    queryParameters.push(
+      queryParameter("resourcePathPrefix", "STRING", params.resourcePathPrefix)
+    );
+  }
+  if (params.operation) {
+    whereClauses.push("operation = @operation");
+    queryParameters.push(
+      queryParameter("operation", "STRING", params.operation)
+    );
+  }
+  if (params.actor) {
+    whereClauses.push("actor = @actor");
+    queryParameters.push(queryParameter("actor", "STRING", params.actor));
+  }
+  if (params.requestId) {
+    whereClauses.push("request_id = @requestId");
+    queryParameters.push(
+      queryParameter("requestId", "STRING", params.requestId)
+    );
+  }
+  if (params.payloadTruncated !== null) {
+    whereClauses.push("payload_truncated = @payloadTruncated");
+    queryParameters.push(
+      queryParameter("payloadTruncated", "BOOL", params.payloadTruncated)
+    );
+  }
+
+  return {
+    query: `
+      SELECT
+        event_id,
+        FORMAT_TIMESTAMP('%FT%T%Ez', commit_timestamp) AS commit_timestamp,
+        FORMAT_TIMESTAMP('%FT%T%Ez', ingest_timestamp) AS ingest_timestamp,
+        resource_path,
+        operation,
+        actor,
+        request_id,
+        ${payloadColumns.join(",\n        ")},
+        payload_bytes,
+        payload_truncated,
+        payload_sha256
+      FROM \`${projectId}.${AUDIT_DATASET}.${AUDIT_WRITES_TABLE}\`
+      WHERE ${whereClauses.join("\n        AND ")}
+      ORDER BY commit_timestamp DESC
+      LIMIT @limit
+    `,
+    queryParameters,
+  };
+};
+
+export class BigQueryAuditJournalReader implements AuditJournalReader {
+  private readonly fetchImpl: FetchLike;
+  private readonly getAccessToken: TokenProvider;
+  private readonly projectId?: string;
+
+  constructor({
+    fetchImpl = fetch,
+    getAccessToken = () => getMetadataAccessToken(fetchImpl),
+    projectId,
+  }: {
+    fetchImpl?: FetchLike;
+    getAccessToken?: TokenProvider;
+    projectId?: string;
+  } = {}) {
+    this.fetchImpl = fetchImpl;
+    this.getAccessToken = getAccessToken;
+    this.projectId = projectId;
+  }
+
+  async query(
+    params: RequiredAuditJournalQueryParams
+  ): Promise<AuditJournalQueryResult> {
+    const accessToken = await this.getAccessToken();
+    const projectId = this.projectId ?? getProjectId();
+    const { query, queryParameters } = buildAuditJournalQuery(
+      projectId,
+      params
+    );
+    const response = await this.fetchImpl(queryEndpoint(projectId), {
+      method: "POST",
+      headers: authHeaders(accessToken),
+      body: JSON.stringify({
+        query,
+        useLegacySql: false,
+        parameterMode: "NAMED",
+        queryParameters,
+        maxResults: params.limit,
+        ...(params.pageToken && { pageToken: params.pageToken }),
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `BigQuery query failed with ${
+          response.status
+        }: ${await response.text()}`
+      );
+    }
+
+    const body = (await response.json()) as BigQueryQueryResponse;
+    if (body.jobComplete === false) {
+      throw new Error("BigQuery query did not complete synchronously");
+    }
+    if (body.errors?.length) {
+      throw new Error(
+        `BigQuery query failed: ${body.errors
+          .map((error) => error.message)
+          .filter(Boolean)
+          .join("; ")}`
+      );
+    }
+
+    return {
+      rows: mapQueryRows(body),
+      ...(body.pageToken && { nextPageToken: body.pageToken }),
+    };
   }
 }

--- a/functions/levante-admin/src/audit/bigqueryClient.ts
+++ b/functions/levante-admin/src/audit/bigqueryClient.ts
@@ -1,0 +1,86 @@
+import {
+  AUDIT_DATASET,
+  AUDIT_WRITES_TABLE,
+  type JournalRow,
+  type JournalWriter,
+} from "./types.js";
+
+type FetchLike = typeof fetch;
+type TokenProvider = () => Promise<string>;
+
+const METADATA_TOKEN_URL =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+export const getProjectId = (): string => {
+  const projectId = process.env.GCLOUD_PROJECT ?? process.env.GCP_PROJECT;
+  if (!projectId) {
+    throw new Error("GCLOUD_PROJECT is required to write audit journal rows");
+  }
+  return projectId;
+};
+
+export const getMetadataAccessToken = async (
+  fetchImpl: FetchLike = fetch
+): Promise<string> => {
+  const response = await fetchImpl(METADATA_TOKEN_URL, {
+    headers: { "Metadata-Flavor": "Google" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Metadata token request failed with ${response.status}`);
+  }
+
+  const body = (await response.json()) as { access_token?: unknown };
+  if (typeof body.access_token !== "string" || body.access_token.length === 0) {
+    throw new Error("Metadata token response did not include access_token");
+  }
+
+  return body.access_token;
+};
+
+export class BigQueryJournalWriter implements JournalWriter {
+  private readonly fetchImpl: FetchLike;
+  private readonly getAccessToken: TokenProvider;
+  private readonly projectId?: string;
+
+  constructor({
+    fetchImpl = fetch,
+    getAccessToken = () => getMetadataAccessToken(fetchImpl),
+    projectId,
+  }: {
+    fetchImpl?: FetchLike;
+    getAccessToken?: TokenProvider;
+    projectId?: string;
+  } = {}) {
+    this.fetchImpl = fetchImpl;
+    this.getAccessToken = getAccessToken;
+    this.projectId = projectId;
+  }
+
+  async insert(row: JournalRow): Promise<void> {
+    const accessToken = await this.getAccessToken();
+    const projectId = this.projectId ?? getProjectId();
+    const url = new URL(
+      `https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${AUDIT_DATASET}/tables/${AUDIT_WRITES_TABLE}/insertAll`
+    );
+
+    const response = await this.fetchImpl(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        rows: [{ insertId: row.event_id, json: row }],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `BigQuery insertAll failed with ${
+          response.status
+        }: ${await response.text()}`
+      );
+    }
+  }
+}

--- a/functions/levante-admin/src/audit/getAuditJournalRows.test.ts
+++ b/functions/levante-admin/src/audit/getAuditJournalRows.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getAuditJournalRowsHandler,
+  hasSuperAdminClaim,
+  normalizeAuditJournalQueryParams,
+} from "./getAuditJournalRows.js";
+import type {
+  AuditJournalReader,
+  RequiredAuditJournalQueryParams,
+} from "./types.js";
+
+const authWithClaims = (customClaims: Record<string, unknown>) => ({
+  getUser: vi.fn().mockResolvedValue({ customClaims }),
+});
+
+describe("getAuditJournalRows", () => {
+  it("recognizes super_admin from supported claim shapes", () => {
+    expect(hasSuperAdminClaim({ super_admin: true })).toBe(true);
+    expect(hasSuperAdminClaim({ rolesSet: ["super_admin"] })).toBe(true);
+    expect(hasSuperAdminClaim({ roles: [{ role: "super_admin" }] })).toBe(true);
+    expect(hasSuperAdminClaim({ siteRoles: { global: ["super_admin"] } })).toBe(
+      true
+    );
+    expect(hasSuperAdminClaim({ rolesSet: ["site_admin"] })).toBe(false);
+  });
+
+  it("normalizes query params with safe defaults and bounds", () => {
+    const params = normalizeAuditJournalQueryParams(
+      {
+        operation: "delete",
+        resourcePathPrefix: "users/",
+        payloadTruncated: true,
+        includePayloads: true,
+        limit: 500,
+      },
+      new Date("2026-08-15T12:00:00.000Z")
+    );
+
+    expect(params).toEqual({
+      startTime: "2026-08-14T12:00:00.000Z",
+      endTime: "2026-08-15T12:00:00.000Z",
+      resourcePath: null,
+      resourcePathPrefix: "users/",
+      operation: "delete",
+      actor: null,
+      requestId: null,
+      payloadTruncated: true,
+      includePayloads: true,
+      limit: 100,
+      pageToken: null,
+    });
+  });
+
+  it("rejects non-super-admin callers", async () => {
+    await expect(
+      getAuditJournalRowsHandler({
+        requesterUid: "site-admin",
+        data: {},
+        auth: authWithClaims({ rolesSet: ["site_admin"] }),
+        reader: { query: vi.fn() },
+      })
+    ).rejects.toMatchObject({
+      code: "permission-denied",
+    });
+  });
+
+  it("queries BigQuery for super admins", async () => {
+    const query =
+      vi.fn<(_: RequiredAuditJournalQueryParams) => Promise<{ rows: [] }>>();
+    query.mockResolvedValue({ rows: [] });
+    const reader: AuditJournalReader = { query };
+
+    await expect(
+      getAuditJournalRowsHandler({
+        requesterUid: "super-admin",
+        data: {
+          startTime: "2026-08-14T00:00:00.000Z",
+          endTime: "2026-08-15T00:00:00.000Z",
+          resourcePath: "users/test-user",
+          limit: 10,
+        },
+        auth: authWithClaims({ rolesSet: ["super_admin"] }),
+        reader,
+      })
+    ).resolves.toEqual({ rows: [] });
+
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startTime: "2026-08-14T00:00:00.000Z",
+        endTime: "2026-08-15T00:00:00.000Z",
+        resourcePath: "users/test-user",
+        limit: 10,
+      })
+    );
+  });
+});

--- a/functions/levante-admin/src/audit/getAuditJournalRows.ts
+++ b/functions/levante-admin/src/audit/getAuditJournalRows.ts
@@ -1,0 +1,162 @@
+import { getAuth, type Auth } from "firebase-admin/auth";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+import { BigQueryAuditJournalReader } from "./bigqueryClient.js";
+import {
+  type AuditJournalQueryParams,
+  type AuditJournalQueryResult,
+  type AuditJournalReader,
+  type JournalOperation,
+  type RequiredAuditJournalQueryParams,
+} from "./types.js";
+
+const DEFAULT_LOOKBACK_HOURS = 24;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const VALID_OPERATIONS = new Set<JournalOperation>([
+  "create",
+  "update",
+  "delete",
+]);
+
+type AuthReader = Pick<Auth, "getUser">;
+
+const auditJournalReader = new BigQueryAuditJournalReader();
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const optionalString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+
+const optionalBoolean = (value: unknown): boolean | null =>
+  typeof value === "boolean" ? value : null;
+
+const dateString = (value: unknown, fallback: Date, field: string): string => {
+  const raw = optionalString(value);
+  if (!raw) return fallback.toISOString();
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new HttpsError("invalid-argument", `${field} must be a valid date`);
+  }
+  return parsed.toISOString();
+};
+
+const limitValue = (value: unknown): number => {
+  if (value === undefined || value === null) return DEFAULT_LIMIT;
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new HttpsError("invalid-argument", "limit must be an integer");
+  }
+  if (value < 1) return 1;
+  return Math.min(value, MAX_LIMIT);
+};
+
+const operationValue = (value: unknown): JournalOperation | null => {
+  const operation = optionalString(value);
+  if (!operation) return null;
+  if (!VALID_OPERATIONS.has(operation as JournalOperation)) {
+    throw new HttpsError(
+      "invalid-argument",
+      "operation must be create, update, or delete"
+    );
+  }
+  return operation as JournalOperation;
+};
+
+export const normalizeAuditJournalQueryParams = (
+  data: unknown,
+  now = new Date()
+): RequiredAuditJournalQueryParams => {
+  const input = asRecord(data);
+  const defaultStart = new Date(
+    now.getTime() - DEFAULT_LOOKBACK_HOURS * 60 * 60 * 1000
+  );
+  const startTime = dateString(input.startTime, defaultStart, "startTime");
+  const endTime = dateString(input.endTime, now, "endTime");
+
+  if (new Date(startTime).getTime() > new Date(endTime).getTime()) {
+    throw new HttpsError(
+      "invalid-argument",
+      "startTime must be before endTime"
+    );
+  }
+
+  return {
+    startTime,
+    endTime,
+    resourcePath: optionalString(input.resourcePath),
+    resourcePathPrefix: optionalString(input.resourcePathPrefix),
+    operation: operationValue(input.operation),
+    actor: optionalString(input.actor),
+    requestId: optionalString(input.requestId),
+    payloadTruncated: optionalBoolean(input.payloadTruncated),
+    includePayloads: input.includePayloads === true,
+    limit: limitValue(input.limit),
+    pageToken: optionalString(input.pageToken),
+  };
+};
+
+export const hasSuperAdminClaim = (
+  customClaims: Record<string, unknown>
+): boolean => {
+  if (customClaims.super_admin === true) return true;
+
+  const rolesSet = customClaims.rolesSet;
+  if (Array.isArray(rolesSet) && rolesSet.includes("super_admin")) {
+    return true;
+  }
+
+  const roles = customClaims.roles;
+  if (
+    Array.isArray(roles) &&
+    roles.some((role) => asRecord(role).role === "super_admin")
+  ) {
+    return true;
+  }
+
+  const siteRoles = customClaims.siteRoles;
+  return Object.values(asRecord(siteRoles)).some(
+    (rolesForSite) =>
+      Array.isArray(rolesForSite) && rolesForSite.includes("super_admin")
+  );
+};
+
+export const getAuditJournalRowsHandler = async ({
+  requesterUid,
+  data,
+  auth = getAuth(),
+  reader = auditJournalReader,
+}: {
+  requesterUid: string;
+  data: unknown;
+  auth?: AuthReader;
+  reader?: AuditJournalReader;
+}): Promise<AuditJournalQueryResult> => {
+  const requester = await auth.getUser(requesterUid);
+  const customClaims = asRecord(requester.customClaims);
+
+  if (!hasSuperAdminClaim(customClaims)) {
+    throw new HttpsError(
+      "permission-denied",
+      "You do not have permission to read the audit journal"
+    );
+  }
+
+  return reader.query(normalizeAuditJournalQueryParams(data));
+};
+
+export const getAuditJournalRows = onCall(
+  { memory: "512MiB", timeoutSeconds: 60 },
+  async (request): Promise<AuditJournalQueryResult> => {
+    const requesterUid = request.auth?.uid;
+    if (!requesterUid) {
+      throw new HttpsError("unauthenticated", "User must be authenticated");
+    }
+
+    return getAuditJournalRowsHandler({
+      requesterUid,
+      data: request.data,
+    });
+  }
+);

--- a/functions/levante-admin/src/audit/journalWrite.test.ts
+++ b/functions/levante-admin/src/audit/journalWrite.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildJournalRow,
+  classifyOperation,
+  extractAuditMeta,
+  handleJournalWrite,
+} from "./journalWrite.js";
+import {
+  MAX_JOURNAL_PAYLOAD_BYTES,
+  type AuditDocumentSnapshot,
+  type AuditFirestoreEvent,
+  type DeadLetterMessage,
+  type JournalRow,
+} from "./types.js";
+
+const snapshot = (
+  exists: boolean,
+  data?: Record<string, unknown>
+): AuditDocumentSnapshot => ({
+  exists,
+  data: () => data,
+});
+
+const eventFor = (
+  before: AuditDocumentSnapshot,
+  after: AuditDocumentSnapshot,
+  overrides: Partial<AuditFirestoreEvent> = {}
+): AuditFirestoreEvent => ({
+  id: "event-1",
+  time: "2026-08-14T12:00:00.000Z",
+  document: "users/test-user",
+  data: { before, after },
+  ...overrides,
+});
+
+describe("journalWrite helpers", () => {
+  it("classifies create, update, and delete events", () => {
+    expect(classifyOperation(snapshot(false), snapshot(true, {}))).toBe(
+      "create"
+    );
+    expect(classifyOperation(snapshot(true, {}), snapshot(true, {}))).toBe(
+      "update"
+    );
+    expect(classifyOperation(snapshot(true, {}), snapshot(false))).toBe(
+      "delete"
+    );
+  });
+
+  it("extracts actor and request_id from after data first", () => {
+    expect(
+      extractAuditMeta(
+        { _audit: { actor: "before-actor", request_id: "before-request" } },
+        { _audit: { actor: "after-actor", request_id: "after-request" } }
+      )
+    ).toEqual({ actor: "after-actor", request_id: "after-request" });
+  });
+
+  it("falls back to before audit metadata for deletes", () => {
+    expect(
+      extractAuditMeta(
+        { _audit: { actor: "before-actor", request_id: "before-request" } },
+        null
+      )
+    ).toEqual({ actor: "before-actor", request_id: "before-request" });
+  });
+
+  it("builds a row for an update event", () => {
+    const row = buildJournalRow(
+      eventFor(
+        snapshot(true, { status: "before" }),
+        snapshot(true, {
+          status: "after",
+          _audit: { actor: "user-1", request_id: "request-1" },
+        })
+      )
+    );
+
+    expect(row).toMatchObject({
+      event_id: "event-1",
+      commit_timestamp: "2026-08-14T12:00:00.000Z",
+      resource_path: "users/test-user",
+      operation: "update",
+      actor: "user-1",
+      request_id: "request-1",
+      payload_truncated: false,
+      payload_sha256: null,
+    });
+    expect(JSON.parse(row.after_json ?? "{}")).toEqual({
+      _audit: { actor: "user-1", request_id: "request-1" },
+      status: "after",
+    });
+  });
+
+  it("truncates payloads over 256 KiB and sets a stable hash", () => {
+    const largePayload = "x".repeat(MAX_JOURNAL_PAYLOAD_BYTES + 1);
+    const event = eventFor(snapshot(false), snapshot(true, { largePayload }), {
+      id: "large-event",
+    });
+    const firstRow = buildJournalRow(event);
+    const secondRow = buildJournalRow(event);
+
+    expect(firstRow.payload_truncated).toBe(true);
+    expect(firstRow.before_json).toBeNull();
+    expect(firstRow.after_json).toBeNull();
+    expect(firstRow.payload_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(firstRow.payload_sha256).toBe(secondRow.payload_sha256);
+    expect(firstRow.payload_bytes).toBeGreaterThan(MAX_JOURNAL_PAYLOAD_BYTES);
+  });
+
+  it("publishes to the DLQ and does not throw when BigQuery insert fails", async () => {
+    const insert = vi
+      .fn<(_: JournalRow) => Promise<void>>()
+      .mockRejectedValue(new Error("insert failed"));
+    const publish = vi
+      .fn<(_: DeadLetterMessage) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    const logError = vi.fn();
+
+    await expect(
+      handleJournalWrite(
+        eventFor(snapshot(false), snapshot(true, { ok: true })),
+        {
+          journalWriter: { insert },
+          deadLetterPublisher: { publish },
+          logger: { error: logError },
+        }
+      )
+    ).resolves.toBeUndefined();
+
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_id: "event-1",
+        resource_path: "users/test-user",
+        error_message: "insert failed",
+      })
+    );
+    expect(logError).toHaveBeenCalledWith(
+      "Firestore audit journal write failed",
+      expect.objectContaining({
+        component: "audit.journalWrite",
+        event_id: "event-1",
+      })
+    );
+  });
+});

--- a/functions/levante-admin/src/audit/journalWrite.ts
+++ b/functions/levante-admin/src/audit/journalWrite.ts
@@ -1,0 +1,261 @@
+import { createHash } from "crypto";
+import { logger } from "firebase-functions/v2";
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+import {
+  BigQueryJournalWriter,
+  getMetadataAccessToken,
+  getProjectId,
+} from "./bigqueryClient.js";
+import { redactJournalPayload } from "./redact.js";
+import {
+  AUDIT_DLQ_TOPIC,
+  MAX_JOURNAL_PAYLOAD_BYTES,
+  type AuditDocumentSnapshot,
+  type AuditFirestoreEvent,
+  type AuditMeta,
+  type DeadLetterMessage,
+  type DeadLetterPublisher,
+  type JournalOperation,
+  type JournalRow,
+  type JournalWriter,
+} from "./types.js";
+
+type HandlerDependencies = {
+  journalWriter: JournalWriter;
+  deadLetterPublisher: DeadLetterPublisher;
+  logger: {
+    error(message: string, data?: Record<string, unknown>): void;
+  };
+};
+
+type FetchLike = typeof fetch;
+type TokenProvider = () => Promise<string>;
+
+class PubSubDeadLetterPublisher implements DeadLetterPublisher {
+  private readonly fetchImpl: FetchLike;
+  private readonly getAccessToken: TokenProvider;
+  private readonly projectId?: string;
+
+  constructor({
+    fetchImpl = fetch,
+    getAccessToken = () => getMetadataAccessToken(fetchImpl),
+    projectId,
+  }: {
+    fetchImpl?: FetchLike;
+    getAccessToken?: TokenProvider;
+    projectId?: string;
+  } = {}) {
+    this.fetchImpl = fetchImpl;
+    this.getAccessToken = getAccessToken;
+    this.projectId = projectId;
+  }
+
+  async publish(message: DeadLetterMessage): Promise<void> {
+    const accessToken = await this.getAccessToken();
+    const projectId = this.projectId ?? getProjectId();
+    const url = new URL(
+      `https://pubsub.googleapis.com/v1/projects/${projectId}/topics/${AUDIT_DLQ_TOPIC}:publish`
+    );
+    const response = await this.fetchImpl(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        messages: [
+          {
+            data: Buffer.from(JSON.stringify(message)).toString("base64"),
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Pub/Sub DLQ publish failed with ${
+          response.status
+        }: ${await response.text()}`
+      );
+    }
+  }
+}
+
+const journalWriter = new BigQueryJournalWriter();
+const deadLetterPublisher = new PubSubDeadLetterPublisher();
+
+export const classifyOperation = (
+  before: AuditDocumentSnapshot,
+  after: AuditDocumentSnapshot
+): JournalOperation => {
+  if (!before.exists && after.exists) return "create";
+  if (before.exists && !after.exists) return "delete";
+  return "update";
+};
+
+const valueToString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+export const extractAuditMeta = (
+  beforeData: Record<string, unknown> | null,
+  afterData: Record<string, unknown> | null
+): AuditMeta => {
+  const afterAudit = (afterData?._audit ?? null) as Record<
+    string,
+    unknown
+  > | null;
+  const beforeAudit = (beforeData?._audit ?? null) as Record<
+    string,
+    unknown
+  > | null;
+
+  return {
+    actor:
+      valueToString(afterAudit?.actor) ?? valueToString(beforeAudit?.actor),
+    request_id:
+      valueToString(afterAudit?.request_id) ??
+      valueToString(beforeAudit?.request_id),
+  };
+};
+
+const normalizeForJson = (value: unknown): unknown => {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(normalizeForJson);
+  if (value instanceof Date) return value.toISOString();
+  if (typeof (value as { toDate?: unknown })?.toDate === "function") {
+    try {
+      return (value as { toDate: () => Date }).toDate().toISOString();
+    } catch {
+      return value;
+    }
+  }
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, normalizeForJson(nestedValue)])
+    );
+  }
+  return value;
+};
+
+export const stableJsonStringify = (value: unknown): string =>
+  JSON.stringify(normalizeForJson(value));
+
+const byteLength = (value: string | null): number =>
+  value ? Buffer.byteLength(value, "utf8") : 0;
+
+const snapshotData = (
+  snapshot: AuditDocumentSnapshot
+): Record<string, unknown> | null =>
+  snapshot.exists ? redactJournalPayload(snapshot.data() ?? {}) : null;
+
+export const buildJournalRow = (event: AuditFirestoreEvent): JournalRow => {
+  if (!event.data) {
+    throw new Error("Firestore event did not include document change data");
+  }
+
+  const { before, after } = event.data;
+  const beforeData = snapshotData(before);
+  const afterData = snapshotData(after);
+  const beforeJson = beforeData ? stableJsonStringify(beforeData) : null;
+  const afterJson = afterData ? stableJsonStringify(afterData) : null;
+  const payloadBytes = byteLength(afterJson ?? beforeJson);
+  const payloadMaterial = stableJsonStringify({
+    before: beforeJson,
+    after: afterJson,
+  });
+  const payloadTruncated = payloadBytes > MAX_JOURNAL_PAYLOAD_BYTES;
+  const auditMeta = extractAuditMeta(beforeData, afterData);
+
+  return {
+    event_id: event.id,
+    commit_timestamp: new Date(event.time ?? Date.now()).toISOString(),
+    ingest_timestamp: new Date().toISOString(),
+    resource_path: getResourcePath(event),
+    operation: classifyOperation(before, after),
+    actor: auditMeta.actor,
+    request_id: auditMeta.request_id,
+    before_json: payloadTruncated ? null : beforeJson,
+    after_json: payloadTruncated ? null : afterJson,
+    payload_bytes: payloadBytes,
+    payload_truncated: payloadTruncated,
+    payload_sha256: payloadTruncated
+      ? createHash("sha256").update(payloadMaterial).digest("hex")
+      : null,
+  };
+};
+
+const getResourcePath = (event: AuditFirestoreEvent): string =>
+  event.document ?? event.params?.document ?? "unknown";
+
+const rawEventForDlq = (event: AuditFirestoreEvent): unknown => ({
+  id: event.id,
+  time: event.time,
+  document: event.document,
+  params: event.params,
+  before: event.data?.before.exists
+    ? normalizeForJson(event.data.before.data() ?? {})
+    : null,
+  after: event.data?.after.exists
+    ? normalizeForJson(event.data.after.data() ?? {})
+    : null,
+});
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+export const handleJournalWrite = async (
+  event: AuditFirestoreEvent,
+  dependencies: HandlerDependencies
+): Promise<void> => {
+  const resourcePath = getResourcePath(event);
+
+  try {
+    const row = buildJournalRow(event);
+    await dependencies.journalWriter.insert(row);
+  } catch (error) {
+    const message = errorMessage(error);
+
+    dependencies.logger.error("Firestore audit journal write failed", {
+      component: "audit.journalWrite",
+      event_id: event.id,
+      resource_path: resourcePath,
+      error_message: message,
+      project_id: process.env.GCLOUD_PROJECT ?? null,
+    });
+
+    try {
+      await dependencies.deadLetterPublisher.publish({
+        event_id: event.id,
+        resource_path: resourcePath,
+        error_message: message,
+        raw_event: rawEventForDlq(event),
+      });
+    } catch (dlqError) {
+      dependencies.logger.error("Firestore audit journal DLQ publish failed", {
+        component: "audit.journalWrite",
+        event_id: event.id,
+        resource_path: resourcePath,
+        error_message: errorMessage(dlqError),
+        project_id: process.env.GCLOUD_PROJECT ?? null,
+      });
+    }
+  }
+};
+
+export const journalWrite = onDocumentWritten(
+  {
+    database: "(default)",
+    document: "{document=**}",
+    memory: "512MiB",
+    retry: false,
+  },
+  async (event) => {
+    await handleJournalWrite(event as AuditFirestoreEvent, {
+      journalWriter,
+      deadLetterPublisher,
+      logger,
+    });
+  }
+);

--- a/functions/levante-admin/src/audit/redact.ts
+++ b/functions/levante-admin/src/audit/redact.ts
@@ -1,0 +1,3 @@
+export const redactJournalPayload = (
+  payload: Record<string, unknown> | null
+): Record<string, unknown> | null => payload;

--- a/functions/levante-admin/src/audit/types.ts
+++ b/functions/levante-admin/src/audit/types.ts
@@ -25,6 +25,45 @@ export type JournalRow = {
   payload_sha256: string | null;
 };
 
+export type AuditJournalQueryParams = {
+  startTime?: string;
+  endTime?: string;
+  resourcePath?: string;
+  resourcePathPrefix?: string;
+  operation?: JournalOperation;
+  actor?: string;
+  requestId?: string;
+  payloadTruncated?: boolean;
+  includePayloads?: boolean;
+  limit?: number;
+  pageToken?: string;
+};
+
+export type AuditJournalQueryResult = {
+  rows: JournalRow[];
+  nextPageToken?: string;
+};
+
+export type AuditJournalReader = {
+  query(
+    params: RequiredAuditJournalQueryParams
+  ): Promise<AuditJournalQueryResult>;
+};
+
+export type RequiredAuditJournalQueryParams = {
+  startTime: string;
+  endTime: string;
+  resourcePath: string | null;
+  resourcePathPrefix: string | null;
+  operation: JournalOperation | null;
+  actor: string | null;
+  requestId: string | null;
+  payloadTruncated: boolean | null;
+  includePayloads: boolean;
+  limit: number;
+  pageToken: string | null;
+};
+
 export type DeadLetterMessage = {
   event_id: string;
   resource_path: string;

--- a/functions/levante-admin/src/audit/types.ts
+++ b/functions/levante-admin/src/audit/types.ts
@@ -1,0 +1,63 @@
+export const AUDIT_DATASET = "levante_audit";
+export const AUDIT_WRITES_TABLE = "writes_journal";
+export const AUDIT_DLQ_TOPIC = "levante-audit-journal-dlq";
+export const MAX_JOURNAL_PAYLOAD_BYTES = 256 * 1024;
+
+export type JournalOperation = "create" | "update" | "delete";
+
+export type AuditMeta = {
+  actor: string | null;
+  request_id: string | null;
+};
+
+export type JournalRow = {
+  event_id: string;
+  commit_timestamp: string;
+  ingest_timestamp: string;
+  resource_path: string;
+  operation: JournalOperation;
+  actor: string | null;
+  request_id: string | null;
+  before_json: string | null;
+  after_json: string | null;
+  payload_bytes: number;
+  payload_truncated: boolean;
+  payload_sha256: string | null;
+};
+
+export type DeadLetterMessage = {
+  event_id: string;
+  resource_path: string;
+  error_message: string;
+  raw_event: unknown;
+};
+
+export type JournalWriter = {
+  insert(row: JournalRow): Promise<void>;
+};
+
+export type DeadLetterPublisher = {
+  publish(message: DeadLetterMessage): Promise<void>;
+};
+
+export type AuditLogger = {
+  error(message: string, data?: Record<string, unknown>): void;
+};
+
+export type AuditDocumentSnapshot = {
+  exists: boolean;
+  data(): Record<string, unknown> | undefined;
+};
+
+export type AuditDocumentChange = {
+  before: AuditDocumentSnapshot;
+  after: AuditDocumentSnapshot;
+};
+
+export type AuditFirestoreEvent = {
+  id: string;
+  time?: string;
+  document?: string;
+  data?: AuditDocumentChange;
+  params?: Record<string, string>;
+};

--- a/functions/levante-admin/src/index.ts
+++ b/functions/levante-admin/src/index.ts
@@ -975,6 +975,7 @@ export const upsertAdministration = onCall(async (request) => {
 
 export { completeTask } from "./tasks/completeTask.js";
 export { startTask } from "./tasks/startTask.js";
+export { getAuditJournalRows } from "./audit/getAuditJournalRows.js";
 export { journalWrite } from "./audit/journalWrite.js";
 
 /**

--- a/functions/levante-admin/src/index.ts
+++ b/functions/levante-admin/src/index.ts
@@ -975,6 +975,7 @@ export const upsertAdministration = onCall(async (request) => {
 
 export { completeTask } from "./tasks/completeTask.js";
 export { startTask } from "./tasks/startTask.js";
+export { journalWrite } from "./audit/journalWrite.js";
 
 /**
  * Syncs run document changes to assignment best-run and completion status.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "vitest run functions/levante-admin/src --config vitest.unit.config.mts",
     "test:e2e": "npm run build && firebase emulators:exec \"vitest run __tests__/e2e --config vitest.e2e.config.mts\"",
+    "test:audit": "npm run build && vitest run functions/levante-admin/src/audit --config vitest.unit.config.mts && firebase emulators:exec --only firestore \"vitest run __tests__/e2e/audit --config vitest.e2e.config.mts\"",
     "test:rules": "firebase emulators:exec \"npx vitest run __tests__/rules\"",
     "predeploy:levante-admin": "npm run build",
     "predeploy:levante-assessment": "npm run build",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "npm run build && firebase emulators:exec \"vitest run __tests__/e2e --config vitest.e2e.config.mts\"",
     "test:audit": "npm run build && vitest run functions/levante-admin/src/audit --config vitest.unit.config.mts && firebase emulators:exec --only firestore \"vitest run __tests__/e2e/audit --config vitest.e2e.config.mts\"",
     "test:rules": "firebase emulators:exec \"npx vitest run __tests__/rules\"",
+    "audit:journal": "node functions/levante-admin/scripts/audit/query_journal.mjs",
     "predeploy:levante-admin": "npm run build",
     "predeploy:levante-assessment": "npm run build",
     "deploy:levante-admin": "firebase deploy --only functions --prefix ./functions/levante-admin/firebase.json",


### PR DESCRIPTION
## Summary
- Add a `journalWrite` Firestore v2 trigger for default-database writes, streaming append-only audit rows to BigQuery.
- Add DLQ publishing, payload truncation/hash guardrails, audit metadata extraction, and a no-op redaction hook.
- Add setup scripts, audit docs, focused unit coverage, and a Firestore-emulator-backed audit test.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:audit`

## Notes
- This PR does not deploy to production.
- Dev rollout requires running `functions/levante-admin/scripts/audit/create_dataset.sh hs-levante-admin-dev`, applying IAM grants, and deploying `functions:journalWrite` to `hs-levante-admin-dev`.