### PR TITLE
Caregiver survey completion can write progress.survey instead of progress.caregiver_survey

### DIFF
--- a/functions/levante-admin/src/save-survey-results.ts
+++ b/functions/levante-admin/src/save-survey-results.ts
@@ -36,6 +36,27 @@ function isSurveyTask(taskId?: string): boolean {
   return !!taskId && taskId.toLowerCase().includes("survey");
 }
 
+function surveyTaskIdForUserType(userType?: string): string | undefined {
+  const type = userType?.toLowerCase();
+  if (type === "parent" || type === "caregiver") return "caregiver-survey";
+  if (type === "teacher") return "teacher-survey";
+  if (type === "student" || type === "child") return "child-survey";
+  return undefined;
+}
+
+function findSurveyAssessmentIndex(
+  assessments: { taskId?: string }[],
+  userType?: string
+): number {
+  const preferred = surveyTaskIdForUserType(userType);
+  if (preferred) {
+    const idx = assessments.findIndex((a) => a.taskId === preferred);
+    if (idx !== -1) return idx;
+  }
+
+  return assessments.findIndex((a) => isSurveyTask(a.taskId));
+}
+
 export async function writeSurveyResponses(
   requesterUid: string,
   data: SurveyResponsesInput
@@ -178,8 +199,9 @@ export async function writeSurveyResponses(
         const assessments = assignmentData?.assessments || [];
 
         // Find the survey assessment
-        const surveyAssessmentIndex = assessments.findIndex((assessment) =>
-          isSurveyTask(assessment.taskId)
+        const surveyAssessmentIndex = findSurveyAssessmentIndex(
+          assessments,
+          userType
         );
 
         if (surveyAssessmentIndex !== -1) {


### PR DESCRIPTION
## Proposed changes

I added a function to check the user type when saving survey progress.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
