### PR TITLE
feat: getUsersByOrg callable

### DIFF
--- a/__tests__/e2e/users/get-users-by-org.e2e.test.ts
+++ b/__tests__/e2e/users/get-users-by-org.e2e.test.ts
@@ -118,7 +118,10 @@ describe("getUsersByOrg (e2e)", () => {
     await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
     await expect(
       getUsersByOrg({ orgType: "school", orgId: "missing" })
-    ).rejects.toMatchObject({ code: "functions/not-found" });
+    ).rejects.toMatchObject({
+      code: "functions/not-found",
+      details: { code: "org", id: "missing", type: "school" },
+    });
   });
 
   it("returns an empty list for a site with no matching users", async () => {

--- a/__tests__/e2e/users/get-users-by-org.e2e.test.ts
+++ b/__tests__/e2e/users/get-users-by-org.e2e.test.ts
@@ -1,0 +1,300 @@
+import type {
+  GetUsersByOrgParams,
+  GetUsersByOrgResult,
+} from "@levante-framework/levante-zod";
+import type { HttpsCallable } from "firebase/functions";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  adminDb,
+  clearAuth,
+  clearFirestore,
+  getClient,
+  seedSystemPermissions,
+  signInAs,
+} from "../app";
+
+const SITE = "site-1";
+const OTHER_SITE = "site-2";
+const SCHOOL = "school-a";
+const CLASS = "class-1";
+const COHORT = "cohort-1";
+
+const SITE_ADMIN_CLAIMS = {
+  useNewPermissions: true,
+  siteRoles: { [SITE]: ["site_admin"] },
+};
+
+describe("getUsersByOrg (e2e)", () => {
+  let client: ReturnType<typeof getClient>;
+  let getUsersByOrg: HttpsCallable<GetUsersByOrgParams, GetUsersByOrgResult>;
+
+  beforeEach(async () => {
+    await Promise.all([clearFirestore(), clearAuth()]);
+    await seedSystemPermissions();
+    client = getClient();
+    getUsersByOrg = client.call<GetUsersByOrgParams, GetUsersByOrgResult>(
+      "getUsersByOrg"
+    );
+  });
+
+  afterEach(() => client.cleanup());
+
+  it("rejects unauthenticated callers", async () => {
+    await expect(
+      getUsersByOrg({ orgType: "site", orgId: SITE })
+    ).rejects.toMatchObject({ code: "functions/unauthenticated" });
+  });
+
+  it("rejects invalid input with a per-field details payload", async () => {
+    await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
+
+    await expect(
+      // @ts-expect-error intentionally missing orgId
+      getUsersByOrg({ orgType: "site" })
+    ).rejects.toMatchObject({
+      code: "functions/invalid-argument",
+      details: {
+        code: "schema",
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: "orgId",
+            message: expect.any(String),
+          }),
+        ]),
+      },
+    });
+
+    await expect(
+      // @ts-expect-error intentionally invalid orgType
+      getUsersByOrg({ orgType: "planet", orgId: SITE })
+    ).rejects.toMatchObject({
+      code: "functions/invalid-argument",
+      details: {
+        code: "schema",
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: "orgType",
+            message: expect.any(String),
+          }),
+        ]),
+      },
+    });
+  });
+
+  it("rejects callers who have not been migrated to the new permission system", async () => {
+    await signInAs(client, "u-legacy", {
+      siteRoles: { [SITE]: ["site_admin"] },
+    });
+    await expect(
+      getUsersByOrg({ orgType: "site", orgId: SITE })
+    ).rejects.toMatchObject({ code: "functions/permission-denied" });
+  });
+
+  it("rejects migrated callers with no site roles", async () => {
+    await signInAs(client, "u-no-roles", { useNewPermissions: true });
+    await expect(
+      getUsersByOrg({ orgType: "site", orgId: SITE })
+    ).rejects.toMatchObject({ code: "functions/permission-denied" });
+  });
+
+  it("rejects callers without read access to the org's site", async () => {
+    await signInAs(client, "u-other", {
+      useNewPermissions: true,
+      siteRoles: { [OTHER_SITE]: ["site_admin"] },
+    });
+    await seedFixture();
+
+    await expect(
+      getUsersByOrg({ orgType: "site", orgId: SITE })
+    ).rejects.toMatchObject({ code: "functions/permission-denied" });
+    // Permission is enforced on the resolved site, so a school owned by SITE
+    // is also off-limits to an OTHER_SITE admin.
+    await expect(
+      getUsersByOrg({ orgType: "school", orgId: SCHOOL })
+    ).rejects.toMatchObject({ code: "functions/permission-denied" });
+  });
+
+  it("returns not-found for an org that does not exist", async () => {
+    await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
+    await expect(
+      getUsersByOrg({ orgType: "school", orgId: "missing" })
+    ).rejects.toMatchObject({ code: "functions/not-found" });
+  });
+
+  it("returns an empty list for a site with no matching users", async () => {
+    await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
+    const { data } = await getUsersByOrg({ orgType: "site", orgId: SITE });
+    expect(data).toEqual({ users: [] });
+  });
+
+  it("returns site members, mapping ROAR user types and excluding archived/disabled/off-site/invalid docs", async () => {
+    await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
+    await seedFixture();
+
+    const { data } = await getUsersByOrg({ orgType: "site", orgId: SITE });
+
+    expect(data.users).toEqual(
+      expect.arrayContaining([
+        { uid: "u-teacher", email: "teacher@example.com", userType: "teacher" },
+        {
+          uid: "u-child",
+          email: "child@example.com",
+          userType: "child",
+          childLabelIndex: 3,
+        },
+        {
+          uid: "u-caregiver",
+          email: "caregiver@example.com",
+          userType: "caregiver",
+        },
+        { uid: "u-site-admin", email: "admin@example.com", userType: "admin" },
+      ])
+    );
+    expect(data.users).toHaveLength(4);
+  });
+
+  it("returns members of a school by resolving its owning site", async () => {
+    await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
+    await seedFixture();
+
+    const { data } = await getUsersByOrg({ orgType: "school", orgId: SCHOOL });
+
+    expect(data.users.map((u) => u.uid).sort()).toEqual([
+      "u-child",
+      "u-teacher",
+    ]);
+  });
+
+  it("returns members of a class by resolving its owning site", async () => {
+    await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
+    await seedFixture();
+
+    const { data } = await getUsersByOrg({ orgType: "class", orgId: CLASS });
+
+    expect(data.users.map((u) => u.uid).sort()).toEqual([
+      "u-child",
+      "u-teacher",
+    ]);
+  });
+
+  it("returns members of a cohort, resolving its site from the groups collection", async () => {
+    await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
+    await seedFixture();
+
+    const { data } = await getUsersByOrg({ orgType: "cohort", orgId: COHORT });
+
+    expect(data.users.map((u) => u.uid).sort()).toEqual([
+      "u-caregiver",
+      "u-child",
+      "u-teacher",
+    ]);
+  });
+});
+
+// Seeds one site with a mix of valid, excluded, and invalid user docs plus the
+// org docs needed to resolve non-site org types to their owning site.
+async function seedFixture() {
+  const batch = adminDb.batch();
+
+  batch.set(adminDb.doc(`schools/${SCHOOL}`), {
+    name: "School A",
+    districtId: SITE,
+    archived: false,
+  });
+  batch.set(adminDb.doc(`classes/${CLASS}`), {
+    name: "Class 1",
+    districtId: SITE,
+    schoolId: SCHOOL,
+    archived: false,
+  });
+  batch.set(adminDb.doc(`groups/${COHORT}`), {
+    name: "Cohort 1",
+    parentOrgId: SITE,
+    parentOrgType: "districts",
+    archived: false,
+  });
+
+  // Valid, active members of the site.
+  batch.set(adminDb.doc("users/u-teacher"), {
+    userType: "teacher",
+    email: "teacher@example.com",
+    archived: false,
+    disabled: false,
+    districts: { current: [SITE] },
+    schools: { current: [SCHOOL] },
+    classes: { current: [CLASS] },
+    groups: { current: [COHORT] },
+  });
+  batch.set(adminDb.doc("users/u-child"), {
+    userType: "student",
+    email: "child@example.com",
+    childLabelIndex: 3,
+    archived: false,
+    disabled: false,
+    districts: { current: [SITE] },
+    schools: { current: [SCHOOL] },
+    classes: { current: [CLASS] },
+    groups: { current: [COHORT] },
+  });
+  batch.set(adminDb.doc("users/u-caregiver"), {
+    userType: "parent",
+    email: "caregiver@example.com",
+    archived: false,
+    disabled: false,
+    districts: { current: [SITE] },
+    groups: { current: [COHORT] },
+  });
+  batch.set(adminDb.doc("users/u-site-admin"), {
+    userType: "admin",
+    email: "admin@example.com",
+    archived: false,
+    disabled: false,
+    districts: { current: [SITE] },
+  });
+
+  // Excluded: archived, disabled, and off-site users.
+  batch.set(adminDb.doc("users/u-archived"), {
+    userType: "teacher",
+    email: "archived@example.com",
+    archived: true,
+    disabled: false,
+    districts: { current: [SITE] },
+    schools: { current: [SCHOOL] },
+    classes: { current: [CLASS] },
+    groups: { current: [COHORT] },
+  });
+  batch.set(adminDb.doc("users/u-disabled"), {
+    userType: "teacher",
+    email: "disabled@example.com",
+    archived: false,
+    disabled: true,
+    districts: { current: [SITE] },
+    schools: { current: [SCHOOL] },
+    classes: { current: [CLASS] },
+    groups: { current: [COHORT] },
+  });
+  batch.set(adminDb.doc("users/u-other-site"), {
+    userType: "teacher",
+    email: "offsite@example.com",
+    archived: false,
+    disabled: false,
+    districts: { current: [OTHER_SITE] },
+  });
+
+  // Invalid: skipped rather than returned (unknown userType, missing email).
+  batch.set(adminDb.doc("users/u-bad-type"), {
+    userType: "wizard",
+    email: "wizard@example.com",
+    archived: false,
+    disabled: false,
+    districts: { current: [SITE] },
+  });
+  batch.set(adminDb.doc("users/u-no-email"), {
+    userType: "teacher",
+    archived: false,
+    disabled: false,
+    districts: { current: [SITE] },
+  });
+
+  await batch.commit();
+}

--- a/__tests__/e2e/users/get-users-by-org.e2e.test.ts
+++ b/__tests__/e2e/users/get-users-by-org.e2e.test.ts
@@ -130,7 +130,7 @@ describe("getUsersByOrg (e2e)", () => {
     expect(data).toEqual({ users: [] });
   });
 
-  it("returns site members, mapping ROAR user types and excluding archived/disabled/off-site/invalid docs", async () => {
+  it("returns site members (including archived/disabled), mapping ROAR user types and excluding off-site/invalid docs", async () => {
     await signInAs(client, "u-admin", SITE_ADMIN_CLAIMS);
     await seedFixture();
 
@@ -151,9 +151,20 @@ describe("getUsersByOrg (e2e)", () => {
           userType: "caregiver",
         },
         { uid: "u-site-admin", email: "admin@example.com", userType: "admin" },
+        // archived and disabled users are no longer filtered out
+        {
+          uid: "u-archived",
+          email: "archived@example.com",
+          userType: "teacher",
+        },
+        {
+          uid: "u-disabled",
+          email: "disabled@example.com",
+          userType: "teacher",
+        },
       ])
     );
-    expect(data.users).toHaveLength(4);
+    expect(data.users).toHaveLength(6);
   });
 
   it("returns members of a school by resolving its owning site", async () => {
@@ -163,7 +174,9 @@ describe("getUsersByOrg (e2e)", () => {
     const { data } = await getUsersByOrg({ orgType: "school", orgId: SCHOOL });
 
     expect(data.users.map((u) => u.uid).sort()).toEqual([
+      "u-archived",
       "u-child",
+      "u-disabled",
       "u-teacher",
     ]);
   });
@@ -175,7 +188,9 @@ describe("getUsersByOrg (e2e)", () => {
     const { data } = await getUsersByOrg({ orgType: "class", orgId: CLASS });
 
     expect(data.users.map((u) => u.uid).sort()).toEqual([
+      "u-archived",
       "u-child",
+      "u-disabled",
       "u-teacher",
     ]);
   });
@@ -187,8 +202,10 @@ describe("getUsersByOrg (e2e)", () => {
     const { data } = await getUsersByOrg({ orgType: "cohort", orgId: COHORT });
 
     expect(data.users.map((u) => u.uid).sort()).toEqual([
+      "u-archived",
       "u-caregiver",
       "u-child",
+      "u-disabled",
       "u-teacher",
     ]);
   });
@@ -217,7 +234,7 @@ async function seedFixture() {
     archived: false,
   });
 
-  // Valid, active members of the site.
+  // Valid members of the site.
   batch.set(adminDb.doc("users/u-teacher"), {
     userType: "teacher",
     email: "teacher@example.com",
@@ -255,7 +272,7 @@ async function seedFixture() {
     districts: { current: [SITE] },
   });
 
-  // Excluded: archived, disabled, and off-site users.
+  // Still returned: archived/disabled users are no longer filtered out.
   batch.set(adminDb.doc("users/u-archived"), {
     userType: "teacher",
     email: "archived@example.com",
@@ -276,6 +293,8 @@ async function seedFixture() {
     classes: { current: [CLASS] },
     groups: { current: [COHORT] },
   });
+
+  // Excluded: off-site user.
   batch.set(adminDb.doc("users/u-other-site"), {
     userType: "teacher",
     email: "offsite@example.com",

--- a/functions/levante-admin/firestore.indexes.json
+++ b/functions/levante-admin/firestore.indexes.json
@@ -880,7 +880,91 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "classes.current",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "disabled",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "districts.current",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "disabled",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "groups.all",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "lastUpdated",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "groups.all",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "lastUpdated",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "groups.current",
           "arrayConfig": "CONTAINS"
         },
         {
@@ -917,90 +1001,6 @@
         {
           "fieldPath": "__name__",
           "order": "ASCENDING"
-        }
-      ],
-      "density": "SPARSE_ALL"
-    },
-    {
-      "collectionGroup": "users",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "classes.current",
-          "arrayConfig": "CONTAINS"
-        },
-        {
-          "fieldPath": "archived",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "disabled",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "ASCENDING"
-        }
-      ],
-      "density": "SPARSE_ALL"
-    },
-    {
-      "collectionGroup": "users",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "groups.current",
-          "arrayConfig": "CONTAINS"
-        },
-        {
-          "fieldPath": "archived",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "disabled",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "ASCENDING"
-        }
-      ],
-      "density": "SPARSE_ALL"
-    },
-    {
-      "collectionGroup": "users",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "groups.all",
-          "arrayConfig": "CONTAINS"
-        },
-        {
-          "fieldPath": "lastUpdated",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "ASCENDING"
-        }
-      ],
-      "density": "SPARSE_ALL"
-    },
-    {
-      "collectionGroup": "users",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "groups.all",
-          "arrayConfig": "CONTAINS"
-        },
-        {
-          "fieldPath": "lastUpdated",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "DESCENDING"
         }
       ],
       "density": "SPARSE_ALL"

--- a/functions/levante-admin/firestore.indexes.json
+++ b/functions/levante-admin/firestore.indexes.json
@@ -903,6 +903,75 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "schools.current",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "disabled",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classes.current",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "disabled",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "groups.current",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "disabled",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "groups.all",
           "arrayConfig": "CONTAINS"
         },

--- a/functions/levante-admin/package.json
+++ b/functions/levante-admin/package.json
@@ -29,7 +29,7 @@
     "@date-fns/tz": "^1.5.0",
     "@firebase/logger": "^0.4.4",
     "@google-cloud/secret-manager": "^4.2.2",
-    "@levante-framework/levante-zod": "^1.2.4",
+    "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
     "@levante-framework/permissions-core": "^1.2.1",
     "axios": "^1.4.0",
     "axios-oauth-1.0a": "^0.3.6",

--- a/functions/levante-admin/package.json
+++ b/functions/levante-admin/package.json
@@ -29,7 +29,7 @@
     "@date-fns/tz": "^1.5.0",
     "@firebase/logger": "^0.4.4",
     "@google-cloud/secret-manager": "^4.2.2",
-    "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
+    "@levante-framework/levante-zod": "^1.3.0",
     "@levante-framework/permissions-core": "^1.2.1",
     "axios": "^1.4.0",
     "axios-oauth-1.0a": "^0.3.6",

--- a/functions/levante-admin/src/firestore-schema.ts
+++ b/functions/levante-admin/src/firestore-schema.ts
@@ -356,8 +356,8 @@ export interface User {
   archived: boolean;
   birthMonth?: number;
   birthYear?: number;
-  childIdentifier?: string;
   childIds?: string[]; // TODO: backfill `studentIds` -> `childIds` in db
+  childLabelIndex?: number;
   classes: OrgAssociationMap;
   createdAt: Timestamp;
   disabled: boolean;

--- a/functions/levante-admin/src/index.ts
+++ b/functions/levante-admin/src/index.ts
@@ -1020,4 +1020,5 @@ export const syncOnRunDocUpdate = onDocumentWritten(
 
 export { getSiteOverview } from "./sites/get-site-overview.js";
 export { getSyncStatus } from "./sites/get-sync-status.js";
+export { getUsersByOrg } from "./users/get-users-by-org.js";
 export { createUsers, syncCreatedUsersTask } from "./users/create-users.js";

--- a/functions/levante-admin/src/orgs/constants.ts
+++ b/functions/levante-admin/src/orgs/constants.ts
@@ -1,0 +1,6 @@
+export const ORG_TYPE_TO_COLLECTION = {
+  site: "districts",
+  school: "schools",
+  class: "classes",
+  cohort: "groups",
+} as const;

--- a/functions/levante-admin/src/orgs/helpers/resolve-site-id.test.ts
+++ b/functions/levante-admin/src/orgs/helpers/resolve-site-id.test.ts
@@ -58,7 +58,7 @@ describe("resolveSiteId", () => {
     const { db } = mockReadDb({});
     await expect(resolveSiteId(db, "school", "missing")).rejects.toMatchObject({
       code: "not-found",
-      details: { code: "org", orgType: "school", orgId: "missing" },
+      details: { code: "org", id: "missing", type: "school" },
     });
   });
 

--- a/functions/levante-admin/src/orgs/helpers/resolve-site-id.test.ts
+++ b/functions/levante-admin/src/orgs/helpers/resolve-site-id.test.ts
@@ -1,0 +1,88 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { describe, expect, it } from "vitest";
+import { resolveSiteId } from "./resolve-site-id.js";
+
+// Serves docs keyed by `collection/id`; a missing key reads as non-existent.
+// Records reads so tests can assert which collection/doc was hit.
+function mockReadDb(docs: Record<string, Record<string, unknown>>) {
+  const reads: { collection: string; id: string }[] = [];
+  const db = {
+    collection: (collection: string) => ({
+      doc: (id: string) => ({
+        get: async () => {
+          reads.push({ collection, id });
+          const data = docs[`${collection}/${id}`];
+          return { exists: data !== undefined, data: () => data };
+        },
+      }),
+    }),
+  } as unknown as Firestore;
+  return { db, reads };
+}
+
+describe("resolveSiteId", () => {
+  it("returns the orgId directly for a site without reading Firestore", async () => {
+    const { db, reads } = mockReadDb({});
+    await expect(resolveSiteId(db, "site", "site-1")).resolves.toBe("site-1");
+    expect(reads).toEqual([]);
+  });
+
+  it("reads a school's districtId", async () => {
+    const { db, reads } = mockReadDb({
+      "schools/school-1": { districtId: "site-1" },
+    });
+    await expect(resolveSiteId(db, "school", "school-1")).resolves.toBe(
+      "site-1"
+    );
+    expect(reads).toEqual([{ collection: "schools", id: "school-1" }]);
+  });
+
+  it("reads a class's districtId", async () => {
+    const { db } = mockReadDb({
+      "classes/class-1": { districtId: "site-1" },
+    });
+    await expect(resolveSiteId(db, "class", "class-1")).resolves.toBe("site-1");
+  });
+
+  it("reads a cohort's parentOrgId from the groups collection", async () => {
+    const { db, reads } = mockReadDb({
+      "groups/cohort-1": { parentOrgId: "site-1", parentOrgType: "districts" },
+    });
+    await expect(resolveSiteId(db, "cohort", "cohort-1")).resolves.toBe(
+      "site-1"
+    );
+    expect(reads).toEqual([{ collection: "groups", id: "cohort-1" }]);
+  });
+
+  it("throws not-found when the org does not exist", async () => {
+    const { db } = mockReadDb({});
+    await expect(resolveSiteId(db, "school", "missing")).rejects.toMatchObject({
+      code: "not-found",
+      details: { code: "org", orgType: "school", orgId: "missing" },
+    });
+  });
+
+  it("throws org-site-missing when a school has no districtId", async () => {
+    const { db } = mockReadDb({
+      "schools/school-1": { name: "Orphan" },
+    });
+    await expect(resolveSiteId(db, "school", "school-1")).rejects.toMatchObject(
+      {
+        code: "internal",
+        details: { code: "org-site-missing", orgType: "school" },
+      }
+    );
+  });
+
+  it("throws org-site-missing when a cohort has no parentOrgId", async () => {
+    const { db } = mockReadDb({
+      "groups/cohort-1": { parentOrgType: "districts" },
+    });
+    await expect(resolveSiteId(db, "cohort", "cohort-1")).rejects.toMatchObject(
+      {
+        code: "internal",
+        details: { code: "org-site-missing", orgType: "cohort" },
+      }
+    );
+  });
+});

--- a/functions/levante-admin/src/orgs/helpers/resolve-site-id.ts
+++ b/functions/levante-admin/src/orgs/helpers/resolve-site-id.ts
@@ -17,8 +17,8 @@ export async function resolveSiteId(
   if (!snap.exists) {
     throw new HttpsError("not-found", `Org not found`, {
       code: "org",
-      orgType,
-      orgId,
+      id: orgId,
+      type: orgType,
     });
   }
   const doc = snap.data() ?? {};

--- a/functions/levante-admin/src/orgs/helpers/resolve-site-id.ts
+++ b/functions/levante-admin/src/orgs/helpers/resolve-site-id.ts
@@ -1,0 +1,37 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { HttpsError } from "firebase-functions/v2/https";
+import { ORG_TYPE_TO_COLLECTION } from "../constants.js";
+
+/** Resolves the id of the site that owns the given org. */
+export async function resolveSiteId(
+  db: Firestore,
+  orgType: "site" | "school" | "class" | "cohort",
+  orgId: string
+): Promise<string> {
+  if (orgType === "site") return orgId;
+
+  const snap = await db
+    .collection(ORG_TYPE_TO_COLLECTION[orgType])
+    .doc(orgId)
+    .get();
+  if (!snap.exists) {
+    throw new HttpsError("not-found", `Org not found`, {
+      code: "org",
+      orgType,
+      orgId,
+    });
+  }
+  const doc = snap.data() ?? {};
+
+  const siteId = orgType === "cohort" ? doc.parentOrgId : doc.districtId;
+  if (typeof siteId !== "string") {
+    throw new HttpsError("internal", "Org has no site", {
+      code: "org-site-missing",
+      orgType,
+      orgId,
+      siteId,
+    });
+  }
+
+  return siteId;
+}

--- a/functions/levante-admin/src/users/get-users-by-org.ts
+++ b/functions/levante-admin/src/users/get-users-by-org.ts
@@ -7,14 +7,14 @@ import { getAuth } from "firebase-admin/auth";
 import { FieldPath, getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { HttpsError, onCall } from "firebase-functions/v2/https";
+import { ORG_TYPE_TO_COLLECTION } from "../orgs/constants.js";
+import { resolveSiteId } from "../orgs/helpers/resolve-site-id.js";
 import {
   buildPermissionsUserFromAuthRecord,
   ensurePermissionsLoaded,
   filterSitesByPermission,
 } from "../utils/permission-helpers.js";
-import { resolveSiteId } from "../orgs/helpers/resolve-site-id.js";
 import { ROAR_TO_LEVANTE_USERTYPE } from "./user-utils.js";
-import { ORG_TYPE_TO_COLLECTION } from "../orgs/constants.js";
 
 export const getUsersByOrg = onCall(
   async (req): Promise<GetUsersByOrgResult> => {
@@ -98,7 +98,7 @@ export const getUsersByOrg = onCall(
         invalidUsers.push({ uid: doc.id, userType: roarUserType, email });
         continue;
       }
-      
+
       users.push({
         uid: doc.id,
         email,

--- a/functions/levante-admin/src/users/get-users-by-org.ts
+++ b/functions/levante-admin/src/users/get-users-by-org.ts
@@ -81,8 +81,6 @@ export const getUsersByOrg = onCall(
         "array-contains",
         orgId
       )
-      .where("archived", "==", false)
-      .where("disabled", "==", false)
       .select("email", "userType", "childLabelIndex")
       .get();
 

--- a/functions/levante-admin/src/users/get-users-by-org.ts
+++ b/functions/levante-admin/src/users/get-users-by-org.ts
@@ -1,0 +1,119 @@
+import {
+  GetUsersByOrgParamsSchema,
+  type GetUsersByOrgResult,
+} from "@levante-framework/levante-zod";
+import { ACTIONS, RESOURCES } from "@levante-framework/permissions-core";
+import { getAuth } from "firebase-admin/auth";
+import { FieldPath, getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+import {
+  buildPermissionsUserFromAuthRecord,
+  ensurePermissionsLoaded,
+  filterSitesByPermission,
+} from "../utils/permission-helpers.js";
+import { resolveSiteId } from "../orgs/helpers/resolve-site-id.js";
+import { ROAR_TO_LEVANTE_USERTYPE } from "./user-utils.js";
+import { ORG_TYPE_TO_COLLECTION } from "../orgs/constants.js";
+
+export const getUsersByOrg = onCall(
+  async (req): Promise<GetUsersByOrgResult> => {
+    const uid = req.auth?.uid;
+    if (!uid)
+      throw new HttpsError("unauthenticated", "User must be authenticated");
+
+    const parsed = GetUsersByOrgParamsSchema.safeParse(req.data);
+    if (!parsed.success) {
+      throw new HttpsError("invalid-argument", "Invalid request parameters", {
+        code: "schema",
+        issues: parsed.error.issues.map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+        })),
+      });
+    }
+    const { orgType, orgId } = parsed.data;
+
+    const auth = getAuth();
+    const userRecord = await auth.getUser(uid);
+    // Legacy permissions
+    // TODO: remove after migration
+    if (userRecord.customClaims?.useNewPermissions !== true) {
+      logger.warn(
+        "Permission denied for getting users by org: legacy permissions",
+        {
+          requestingUid: uid,
+        }
+      );
+      throw new HttpsError(
+        "permission-denied",
+        "New permission system must be enabled to get users by org"
+      );
+    }
+
+    const db = getFirestore();
+    const siteId = await resolveSiteId(db, orgType, orgId);
+
+    await ensurePermissionsLoaded();
+    const user = buildPermissionsUserFromAuthRecord(userRecord);
+    const allowed =
+      filterSitesByPermission(user, [siteId], {
+        resource: RESOURCES.USERS,
+        action: ACTIONS.READ,
+      }).length > 0;
+    if (!allowed) {
+      logger.warn("Permission denied for getting users by org", {
+        requestingUid: uid,
+        orgType,
+        orgId,
+        siteId,
+      });
+      throw new HttpsError(
+        "permission-denied",
+        `You do not have permission to read users in ${orgType} ${orgId}`
+      );
+    }
+
+    const usersSnap = await db
+      .collection("users")
+      .where(
+        new FieldPath(ORG_TYPE_TO_COLLECTION[orgType], "current"),
+        "array-contains",
+        orgId
+      )
+      .where("archived", "==", false)
+      .where("disabled", "==", false)
+      .select("email", "userType", "childLabelIndex")
+      .get();
+
+    const users: GetUsersByOrgResult["users"] = [];
+    const invalidUsers: { uid: string; [key: string]: unknown }[] = [];
+    for (const doc of usersSnap.docs) {
+      const roarUserType = doc.get("userType");
+      const userType = ROAR_TO_LEVANTE_USERTYPE[roarUserType];
+      const email = doc.get("email");
+      const childLabelIndex = doc.get("childLabelIndex");
+
+      if (!userType || typeof email !== "string") {
+        invalidUsers.push({ uid: doc.id, userType: roarUserType, email });
+        continue;
+      }
+      
+      users.push({
+        uid: doc.id,
+        email,
+        userType,
+        ...(typeof childLabelIndex === "number" ? { childLabelIndex } : {}),
+      });
+    }
+    if (invalidUsers.length > 0) {
+      logger.warn("Skipped invalid user docs", {
+        orgType,
+        orgId,
+        users: invalidUsers,
+      });
+    }
+
+    return { users };
+  }
+);

--- a/functions/levante-admin/src/users/user-utils.ts
+++ b/functions/levante-admin/src/users/user-utils.ts
@@ -4,3 +4,10 @@ export const LEVANTE_TO_ROAR_USERTYPE = {
   child: "student",
   teacher: "teacher",
 } as const;
+
+export const ROAR_TO_LEVANTE_USERTYPE = {
+  admin: "admin",
+  parent: "caregiver",
+  student: "child",
+  teacher: "teacher",
+} as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "functions/levante-admin"
       ],
       "dependencies": {
-        "@levante-framework/levante-zod": "^1.2.4",
+        "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
         "firebase": "^11.6.1",
         "firebase-admin": "^11.11.1",
         "firebase-tools": "^14.27.0"
@@ -43,7 +43,7 @@
         "@date-fns/tz": "^1.5.0",
         "@firebase/logger": "^0.4.4",
         "@google-cloud/secret-manager": "^4.2.2",
-        "@levante-framework/levante-zod": "^1.2.4",
+        "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
         "@levante-framework/permissions-core": "^1.2.1",
         "axios": "^1.4.0",
         "axios-oauth-1.0a": "^0.3.6",
@@ -2818,8 +2818,7 @@
     },
     "node_modules/@levante-framework/levante-zod": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.2.4.tgz",
-      "integrity": "sha512-F3D+58kMVjYG4IQMqsAzTEYdktL3QfJM18yXADuKWIldkxzzVaIa+SYU0fY1tpel384468TKqSGOcWACwTKkKQ==",
+      "resolved": "git+ssh://git@github.com/levante-framework/levante-zod.git#9b560a1a9400644ae269555d7ad076303f50bc5c",
       "license": "MIT",
       "dependencies": {
         "h3-js": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "functions/levante-admin"
       ],
       "dependencies": {
-        "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
+        "@levante-framework/levante-zod": "^1.3.0",
         "firebase": "^11.6.1",
         "firebase-admin": "^11.11.1",
         "firebase-tools": "^14.27.0"
@@ -43,7 +43,7 @@
         "@date-fns/tz": "^1.5.0",
         "@firebase/logger": "^0.4.4",
         "@google-cloud/secret-manager": "^4.2.2",
-        "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
+        "@levante-framework/levante-zod": "^1.3.0",
         "@levante-framework/permissions-core": "^1.2.1",
         "axios": "^1.4.0",
         "axios-oauth-1.0a": "^0.3.6",
@@ -2817,8 +2817,9 @@
       "link": true
     },
     "node_modules/@levante-framework/levante-zod": {
-      "version": "1.2.4",
-      "resolved": "git+ssh://git@github.com/levante-framework/levante-zod.git#9b560a1a9400644ae269555d7ad076303f50bc5c",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.3.0.tgz",
+      "integrity": "sha512-gX8Z4S8Vh6LY8sdq7BBkDzZ4lN41cloCeoG39CGhTKHBXuc2KVmr0aVXBs1XsDnjXYe3KZGkt8To8tn+rvqa/w==",
       "license": "MIT",
       "dependencies": {
         "h3-js": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "*.{js,css,md}": "prettier --write"
   },
   "dependencies": {
-    "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
+    "@levante-framework/levante-zod": "^1.3.0",
     "firebase": "^11.6.1",
     "firebase-admin": "^11.11.1",
     "firebase-tools": "^14.27.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "*.{js,css,md}": "prettier --write"
   },
   "dependencies": {
-    "@levante-framework/levante-zod": "^1.2.4",
+    "@levante-framework/levante-zod": "github:levante-framework/levante-zod#feat/get-users-by-org",
     "firebase": "^11.6.1",
     "firebase-admin": "^11.11.1",
     "firebase-tools": "^14.27.0"


### PR DESCRIPTION
## Proposed changes

Adds a `getUsersByOrg` callable that returns the active users belonging to a given org (site, school, class, or cohort). NB: this returns only what the dashboard currently expects. A future PR will add archived/excluded filtering, paging, etc.

- Add `getUsersByOrg` callable, e2e tests
- Add `resolveSiteId` helper: maps a school/class/cohort to its owning site
- Add three composite `users` indexes (`{schools|classes|groups}.current` + `archived` + `disabled`)
- Bump `@levante-framework/levante-zod` to `^1.3.0` (adds the `GetUsersByOrg*` schemas/types)

## Types of changes

What types of changes does this pull request introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [x] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)